### PR TITLE
docs: update readme badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,10 +3,11 @@
 
 # v-analyzer
 
-[![VSCode Extension](https://img.shields.io/badge/VS_Code-extension-25829e?logo=visualstudiocode&logoWidth=10)](https://marketplace.visualstudio.com/items?itemName=VOSCA.vscode-v-analyzer)
-[![Build CI](https://github.com/vlang/v-analyzer/actions/workflows/build_ci.yml/badge.svg)](https://github.com/vlang/v-analyzer/actions/workflows/build_ci.yml)
-[![Analyzer tests](https://github.com/vlang/v-analyzer/actions/workflows/analyzer_tests.yml/badge.svg)](https://github.com/vlang/v-analyzer/actions/workflows/analyzer_tests.yml)
-[![VS Code extension tests](https://github.com/vlang/v-analyzer/actions/workflows/vscode_extension_tests.yml/badge.svg)](https://github.com/vlang/v-analyzer/actions/workflows/vscode_extension_tests.yml)
+[![][badge__vscode_ext]](https://marketplace.visualstudio.com/items?itemName=VOSCA.vscode-v-analyzer)
+[![][badge__build_ci]](https://github.com/vlang/v-analyzer/actions/workflows/build_ci.yml?query=branch%3Amain)
+[![][badge__tests_ci]](https://github.com/vlang/v-analyzer/actions/workflows/analyzer_tests.yml?query=branch%3Amain)
+[![][badge__tree_sitter_ci]](https://github.com/vlang/v-analyzer/actions/workflows/test_tree_sitter_v.yml?query=branch%3Amain)
+[![][badge__vscode_ext_ci]](https://github.com/vlang/v-analyzer/actions/workflows/vscode_extension_tests.yml?query=branch%3Amain)
 
 Bring IDE features for the V programming language to VS Code, Vim, and other editors.
 
@@ -181,3 +182,8 @@ See the
 [LICENSE](https://github.com/vlang/v-analyzer/blob/main/LICENSE)
 file for the full license text.
 
+[badge__vscode_ext]: https://img.shields.io/badge/VS_Code-extension-1da2e2?logo=visualstudiocode&logoWidth=11&logoColor=959da5&labelColor=333
+[badge__build_ci]: https://img.shields.io/github/actions/workflow/status/vlang/v-analyzer/build_ci.yml?style=flat-rounded&branch=main&logo=github&&logoColor=959da5&labelColor=333&label=Build
+[badge__tests_ci]: https://img.shields.io/github/actions/workflow/status/vlang/v-analyzer/analyzer_tests.yml?style=flat-rounded&branch=main&logo=github&&logoColor=959da5&labelColor=333&label=Analyzer
+[badge__tree_sitter_ci]: https://img.shields.io/github/actions/workflow/status/vlang/v-analyzer/test_tree_sitter_v.yml?style=flat-rounded&branch=main&logo=github&&logoColor=959da5&labelColor=333&label=Tree-sitter
+[badge__vscode_ext_ci]: https://img.shields.io/github/actions/workflow/status/vlang/v-analyzer/vscode_extension_tests.yml?style=flat-rounded&branch=main&logo=github&&logoColor=959da5&labelColor=333&label=VS%20Code%20Extension


### PR DESCRIPTION
Changes visible in the rendered readme:
- Specify main branch for ci badges
- Update names
- Align colors
- Add tree sitter badge

https://github.com/ttytm/v-analyzer/blob/docs/update-badges/README.md