### PR TITLE
test: update tests to run with `v test`

### DIFF
--- a/.github/workflows/analyzer_tests.yml
+++ b/.github/workflows/analyzer_tests.yml
@@ -44,7 +44,4 @@ jobs:
           submodules: true
 
       - name: Run tests
-        run: cd tests && v run .
-
-      - name: Run other V tests
         run: v test .

--- a/tests/analyzer_test.v
+++ b/tests/analyzer_test.v
@@ -1,15 +1,16 @@
-module main
+module tests
 
 import os
 import term
 import testing
 
-fn main() {
+fn test_all() {
 	defer {
 		os.rmdir_all(testing.temp_path) or {
 			println('Failed to remove temp path: ${testing.temp_path}')
 		}
 	}
+	os.chdir(os.join_path(@VMODROOT, 'tests'))!
 
 	mut testers := []testing.Tester{}
 

--- a/tests/bench.v
+++ b/tests/bench.v
@@ -1,4 +1,4 @@
-module main
+module tests
 
 import testing
 

--- a/tests/completion.v
+++ b/tests/completion.v
@@ -1,4 +1,4 @@
-module main
+module tests
 
 import testing
 import server.completion.providers

--- a/tests/definitions.v
+++ b/tests/definitions.v
@@ -1,4 +1,4 @@
-module main
+module tests
 
 import testing
 

--- a/tests/documentation.v
+++ b/tests/documentation.v
@@ -1,4 +1,4 @@
-module main
+module tests
 
 import testing
 

--- a/tests/implementations.v
+++ b/tests/implementations.v
@@ -1,4 +1,4 @@
-module main
+module tests
 
 import testing
 

--- a/tests/supers.v
+++ b/tests/supers.v
@@ -1,4 +1,4 @@
-module main
+module tests
 
 import testing
 

--- a/tests/types.v
+++ b/tests/types.v
@@ -1,4 +1,4 @@
-module main
+module tests
 
 import testing
 


### PR DESCRIPTION
With the change analyzer tests will also be run if `v test .` is run in the project root and are directory independent.

Due to current issues with V's `-stats` flag, it currently won't print more details when used with test runs. To get an extended overview - same as running the tests with `cd tests && v run .`. Execute the tests via `v tests/analyzer_test.v`
