### PR TITLE
refactor: simplify doc_comment_extractor, slightly reduce load

### DIFF
--- a/analyzer/psi/doc_comment_extractor.v
+++ b/analyzer/psi/doc_comment_extractor.v
@@ -3,6 +3,7 @@ module psi
 import strings
 
 pub fn extract_doc_comment(el PsiElement) string {
+	el_start_line := el.node.start_point().row
 	mut comment := el.prev_sibling() or { return '' }
 	if comment !is Comment {
 		comment = comment.prev_sibling() or { return '' }
@@ -11,23 +12,18 @@ pub fn extract_doc_comment(el PsiElement) string {
 	mut comments := []PsiElement{}
 
 	for comment is Comment {
-		func_start_line := el.node.start_point().row
 		comment_start_line := comment.node.start_point().row
 
-		if comment_start_line + 1 + u32(comments.len) != func_start_line {
+		if comment_start_line + 1 + u32(comments.len) != el_start_line {
 			break
 		}
 
-		if prev := comment.prev_sibling() {
-			if prev.node.start_point().row == comment_start_line {
-				break
-			}
-			comments << comment
-			comment = prev
-		} else {
-			comments << comment
+		line := comment.prev_sibling() or { break }
+		if line.node.start_point().row == comment_start_line {
 			break
 		}
+		comments << comment
+		comment = line
 	}
 
 	comments.reverse_in_place()


### PR DESCRIPTION
Simplifying, hoping to make the code semantically easier to follow for maintainability, and removing a repeated variable declaration out of a loop where it is not necessary.
