### PR TITLE
feat: add inline struct field comments

### DIFF
--- a/analyzer/psi/doc_comment_extractor.v
+++ b/analyzer/psi/doc_comment_extractor.v
@@ -26,6 +26,21 @@ pub fn extract_doc_comment(el PsiElement) string {
 		comment = line
 	}
 
+	if comments.len == 0 {
+		if el !is FieldDeclaration {
+			return ''
+		}
+		if next := el.next_sibling() {
+			if next is Comment {
+				func_start_line := el.node.start_point().row
+				comment_start_line := next.node.start_point().row
+				if comment_start_line == func_start_line {
+					return next.get_text().trim_string_left('//').trim_space()
+				}
+			}
+		}
+	}
+
 	comments.reverse_in_place()
 
 	lines := comments.map(it.get_text()

--- a/analyzer/psi/doc_comment_extractor.v
+++ b/analyzer/psi/doc_comment_extractor.v
@@ -27,18 +27,18 @@ pub fn extract_doc_comment(el PsiElement) string {
 	}
 
 	if comments.len == 0 {
-		if el !is FieldDeclaration {
-			return ''
-		}
-		if next := el.next_sibling() {
-			if next is Comment {
-				func_start_line := el.node.start_point().row
-				comment_start_line := next.node.start_point().row
-				if comment_start_line == func_start_line {
-					return next.get_text().trim_string_left('//').trim_space()
+		if el is FieldDeclaration {
+			if next := el.next_sibling() {
+				if next is Comment {
+					func_start_line := el.node.start_point().row
+					comment_start_line := next.node.start_point().row
+					if comment_start_line == func_start_line {
+						return next.get_text().trim_string_left('//').trim_space()
+					}
 				}
 			}
 		}
+		return ''
 	}
 
 	comments.reverse_in_place()

--- a/analyzer/psi/doc_comment_extractor.v
+++ b/analyzer/psi/doc_comment_extractor.v
@@ -32,14 +32,14 @@ pub fn extract_doc_comment(el PsiElement) string {
 			if next is Comment {
 				comment_start_line := next.node.start_point().row
 				if comment_start_line == el_start_line {
-					field_eol_comment = '... ' + next.get_text().trim_string_left('//').trim_space()
+					field_eol_comment = next.get_text().trim_string_left('//').trim_space()
 				}
 			}
 		}
 	}
 
 	if comments.len == 0 {
-		return field_eol_comment
+		return if field_eol_comment != '' { '... ' + field_eol_comment } else { '' }
 	}
 
 	comments.reverse_in_place()
@@ -100,6 +100,6 @@ pub fn extract_doc_comment(el PsiElement) string {
 		}
 	}
 
-	res_str := res.str() + if field_eol_comment != '' { '\n\n' + field_eol_comment } else { '' }
+	res_str := res.str() + if field_eol_comment != '' { '\n\n... ' + field_eol_comment } else { '' }
 	return res_str
 }

--- a/analyzer/psi/doc_comment_extractor.v
+++ b/analyzer/psi/doc_comment_extractor.v
@@ -30,9 +30,8 @@ pub fn extract_doc_comment(el PsiElement) string {
 		if el is FieldDeclaration {
 			if next := el.next_sibling() {
 				if next is Comment {
-					func_start_line := el.node.start_point().row
 					comment_start_line := next.node.start_point().row
-					if comment_start_line == func_start_line {
+					if comment_start_line == el_start_line {
 						return next.get_text().trim_string_left('//').trim_space()
 					}
 				}

--- a/analyzer/psi/doc_comment_extractor.v
+++ b/analyzer/psi/doc_comment_extractor.v
@@ -26,18 +26,20 @@ pub fn extract_doc_comment(el PsiElement) string {
 		comment = line
 	}
 
-	if comments.len == 0 {
-		if el is FieldDeclaration {
-			if next := el.next_sibling() {
-				if next is Comment {
-					comment_start_line := next.node.start_point().row
-					if comment_start_line == el_start_line {
-						return next.get_text().trim_string_left('//').trim_space()
-					}
+	mut field_eol_comment := ''
+	if el is FieldDeclaration {
+		if next := el.next_sibling() {
+			if next is Comment {
+				comment_start_line := next.node.start_point().row
+				if comment_start_line == el_start_line {
+					field_eol_comment = '... ' + next.get_text().trim_string_left('//').trim_space()
 				}
 			}
 		}
-		return ''
+	}
+
+	if comments.len == 0 {
+		return field_eol_comment
 	}
 
 	comments.reverse_in_place()
@@ -98,5 +100,6 @@ pub fn extract_doc_comment(el PsiElement) string {
 		}
 	}
 
-	return res.str()
+	res_str := res.str() + if field_eol_comment != '' { '\n\n' + field_eol_comment } else { '' }
+	return res_str
 }


### PR DESCRIPTION
Allow for inline struct field comments. Comments above a struct field are prioritised.

Adds a fast track exit if comments has a length of 0.