### PR TITLE
feat: use build version aware caching

### DIFF
--- a/config/constants.v
+++ b/config/constants.v
@@ -31,6 +31,10 @@ pub const analyzer_global_config_path = os.join_path(analyzer_configs_path, anal
 // cache files for the analyzer.
 pub const analyzer_caches_path = os.join_path(os.cache_dir(), 'v-analyzer')
 
+// analyzer_caches_path is the path to the directory containing the
+// cache files for the analyzer.
+pub const analyzer_caches_version_path = os.join_path(analyzer_caches_path, 'version.txt')
+
 // analyzer_stubs_path is the path to the directory containing the
 // unpacked stub files for the analyzer.
 pub const analyzer_stubs_path = os.join_path(analyzer_configs_path, 'metadata')

--- a/config/constants.v
+++ b/config/constants.v
@@ -30,7 +30,7 @@ pub const analyzer_global_config_path = os.join_path(analyzer_configs_path, anal
 
 // analyzer_caches_path is the path to the directory containing the
 // cache files for the analyzer.
-pub const analyzer_caches_path = os.join_path(os.cache_dir(), 'v-analyzer', metadata.build_commit)
+pub const analyzer_caches_path = os.join_path(os.cache_dir(), 'v-analyzer', '${metadata.build_commit}_${os.file_last_mod_unix(os.executable())}')
 
 // analyzer_stubs_path is the path to the directory containing the
 // unpacked stub files for the analyzer.

--- a/config/constants.v
+++ b/config/constants.v
@@ -31,10 +31,6 @@ pub const analyzer_global_config_path = os.join_path(analyzer_configs_path, anal
 // cache files for the analyzer.
 pub const analyzer_caches_path = os.join_path(os.cache_dir(), 'v-analyzer')
 
-// analyzer_caches_path is the path to the directory containing the
-// cache files for the analyzer.
-pub const analyzer_caches_version_path = os.join_path(analyzer_caches_path, 'version.txt')
-
 // analyzer_stubs_path is the path to the directory containing the
 // unpacked stub files for the analyzer.
 pub const analyzer_stubs_path = os.join_path(analyzer_configs_path, 'metadata')

--- a/config/constants.v
+++ b/config/constants.v
@@ -1,6 +1,7 @@
 module config
 
 import os
+import metadata
 
 // analyzer_name is the name of the analyzer.
 pub const analyzer_name = 'v-analyzer'
@@ -29,7 +30,7 @@ pub const analyzer_global_config_path = os.join_path(analyzer_configs_path, anal
 
 // analyzer_caches_path is the path to the directory containing the
 // cache files for the analyzer.
-pub const analyzer_caches_path = os.join_path(os.cache_dir(), 'v-analyzer')
+pub const analyzer_caches_path = os.join_path(os.cache_dir(), 'v-analyzer', metadata.build_commit)
 
 // analyzer_stubs_path is the path to the directory containing the
 // unpacked stub files for the analyzer.

--- a/server/general.v
+++ b/server/general.v
@@ -229,7 +229,6 @@ fn (mut ls LanguageServer) setup() {
 	}
 
 	if ls.cache_dir == '' {
-		// if custom cache dir is not set, use default
 		ls.setup_cache_dir()
 	}
 
@@ -237,54 +236,23 @@ fn (mut ls LanguageServer) setup() {
 }
 
 fn (mut ls LanguageServer) setup_cache_dir() {
-	if os.exists(config.analyzer_caches_path) {
-		if os.exists(config.analyzer_caches_version_path) {
-			version := os.read_file(config.analyzer_caches_version_path) or {
-				ls.client.log_message('Failed to read caches version: ${err}', .error)
-
-				loglib.with_fields({
-					'err': err.str()
-				}).error('Failed to read caches version')
-				'0'
-			}
-
-			if version.trim_space() == metadata.build_commit {
-				return
-			}
-		}
-
-		ls.client.log_message('Caches version mismatch, creating new cache', .info)
-		loglib.info('Caches version mismatch, creating new cache')
-
-		os.rmdir_all(config.analyzer_caches_path) or {
-			ls.client.log_message('Failed to remove old caches: ${err}', .error)
+	if !os.exists(config.analyzer_caches_path) {
+		os.mkdir_all(config.analyzer_caches_path) or {
+			ls.client.log_message('Failed to create analyzer caches directory: ${err}',
+				.error)
 
 			loglib.with_fields({
 				'err': err.str()
-			}).error('Failed to remove old caches')
+			}).error('Failed to create analyzer caches directory')
+			return
 		}
 	}
 
+	// if custom cache dir is not set, use default
 	ls.cache_dir = config.analyzer_caches_path
+
 	ls.client.log_message('Using "${ls.cache_dir}" as cache dir', .info)
 	loglib.info('Using "${ls.cache_dir}" as cache dir')
-
-	os.mkdir_all(config.analyzer_caches_path) or {
-		ls.client.log_message('Failed to create caches directory: ${err}', .error)
-
-		loglib.with_fields({
-			'err': err.str()
-		}).error('Failed to create caches directory')
-		return
-	}
-
-	os.write_file(config.analyzer_caches_version_path, metadata.build_commit) or {
-		ls.client.log_message('Failed to write caches version: ${err}', .error)
-
-		loglib.with_fields({
-			'err': err.str()
-		}).error('Failed to write caches version')
-	}
 }
 
 fn (mut ls LanguageServer) find_config() string {


### PR DESCRIPTION
The changes add a version-aware cache. This fixes the issue where an old cache would prevent updates and bug fixes from becoming visible to users.

<details>
<summary><i>obsolete</i></summary>
The versioning follows the same scheme as we do for the metadata/stubs. But instead of using a hardcoded version for the metadata(which is handled separately and changes less often) the changes in the PR add a more dynamic handling for the analyzer's indexing cache based on the build commit. This should be appropriate as it is affected by most commits to the project.


Refs to stubs versioning:
- setup: https://github.com/vlang/v-analyzer/blob/44c804decd62b77a149b5049e1c9f5d9b97f50cf/server/general.v#L345
- version file: https://github.com/vlang/v-analyzer/blob/44c804decd62b77a149b5049e1c9f5d9b97f50cf/config/constants.v#L39
- manual versioning: https://github.com/vlang/v-analyzer/blob/44c804decd62b77a149b5049e1c9f5d9b97f50cf/server/language_server.v#L47-L50

</details>