### PR TITLE
fix: store metadata stubs in cache instead of config dir

### DIFF
--- a/config/constants.v
+++ b/config/constants.v
@@ -33,7 +33,7 @@ pub const analyzer_caches_path = os.join_path(os.cache_dir(), 'v-analyzer')
 
 // analyzer_stubs_path is the path to the directory containing the
 // unpacked stub files for the analyzer.
-pub const analyzer_stubs_path = os.join_path(analyzer_configs_path, 'metadata')
+pub const analyzer_stubs_path = os.join_path(analyzer_caches_path, 'metadata')
 
 // analyzer_stubs_version_path is the path to the file containing the version of the stubs.
 pub const analyzer_stubs_version_path = os.join_path(analyzer_stubs_path, 'version.txt')


### PR DESCRIPTION
Currently, storing the metadata stubs also in the config dir will require removing this metadata dir. Just removing the cache directory when making changes to the metadata is not sufficient. This is a manual step a user should not be required to do. 

For example, also during development I ran into the issue of not being able to reproduce the test failure in #53; just removing the cache directory was not enough. This PR should solve the mentioned problems. The metadata directory is `< 50KB`.

The changes synergize with version aware caching in #57 