### PR TITLE
fix: version regression, add test

### DIFF
--- a/.github/workflows/analyzer_tests.yml
+++ b/.github/workflows/analyzer_tests.yml
@@ -45,3 +45,16 @@ jobs:
 
       - name: Run tests
         run: v test .
+
+      - name: Install v-analyzer
+        if: runner.os != 'Windows'
+        run: |
+          # Build and install v-analyzer at the head ref of the submitted changes.
+          v run build.vsh
+          sudo mv ./bin/v-analyzer /usr/local/bin/v-analyzer
+          v-analyzer --version
+
+      - name: Verify version
+        # TODO: include Windows
+        if: runner.os != 'Windows'
+        run: v .github/workflows/version_test.vv

--- a/.github/workflows/version_test.vv
+++ b/.github/workflows/version_test.vv
@@ -1,0 +1,19 @@
+import os
+import v.vmod
+
+fn test_version() {
+	if os.getenv('CI') != 'true' {
+		eprintln('WARNING: expecting usage in combination with CI workflow.')
+	}
+
+	git_ref := os.getenv('GITHUB_WORKFLOW_SHA').trim_space()[..7]
+	manifest := vmod.decode(@VMOD_FILE)!
+	assert manifest.name == 'v-analyzer'
+
+	// Move out of the project directory to ensure that we exclude the possiblity of
+	// deriving the commit reference from v-analyzer's directory at program startup.
+	os.chdir('/tmp/')!
+	analyzer_version := os.execute_opt('v-analyzer --version')!.output.all_after_last(' ').trim_space()
+
+	assert '${manifest.version}.${git_ref}' == analyzer_version
+}

--- a/build.vsh
+++ b/build.vsh
@@ -7,9 +7,12 @@
 import os
 import cli
 import term
+import time
 import metadata
 
 const bin_path = './bin/v-analyzer' + $if windows { '.exe' } $else { '' }
+const build_commit = os.execute('git rev-parse --short HEAD').output.trim_space()
+const build_datetime = time.now().format_ss()
 
 enum ReleaseMode {
 	release
@@ -58,7 +61,7 @@ fn prepare_output_dir() {
 }
 
 fn build(mode ReleaseMode, explicit_debug bool) {
-	println('Building v-analyzer at commit: ${metadata.build_commit}, build time: ${metadata.build_datetime} ...')
+	println('Building v-analyzer at commit: ${build_commit}, build time: ${build_datetime} ...')
 
 	prepare_output_dir()
 	println('${term.green('✓')} Prepared output directory')
@@ -86,9 +89,12 @@ fn build(mode ReleaseMode, explicit_debug bool) {
 
 // main program:
 
+os.setenv('BUILD_DATETIME', build_datetime, true)
+os.setenv('BUILD_COMMIT', build_commit, true)
+
 mut cmd := cli.Command{
 	name: 'v-analyzer-builder'
-	version: metadata.full_version
+	version: metadata.manifest.version
 	description: 'Builds the v-analyzer binary.'
 	posix_mode: true
 	execute: fn (_ cli.Command) ! {

--- a/metadata/metadata.v
+++ b/metadata/metadata.v
@@ -3,11 +3,10 @@ module metadata
 import os
 import v.vmod
 import v.embed_file
-import time
 
 pub const manifest = vmod.decode(@VMOD_FILE) or { panic(err) }
-pub const build_commit = os.execute('git rev-parse --short HEAD').output.trim_space()
-pub const build_datetime = time.now().format_ss()
+pub const build_datetime = $env('BUILD_DATETIME')
+pub const build_commit = $env('BUILD_COMMIT')
 pub const full_version = manifest.version + '.' + build_commit
 
 struct EmbedFS {
@@ -35,7 +34,6 @@ pub fn embed_fs() EmbedFS {
 	files << $embed_file('stubs/compile_time_reflection.v', .zlib)
 	files << $embed_file('stubs/builtin_compile_time.v', .zlib)
 	files << $embed_file('stubs/channels.v', .zlib)
-	files << $embed_file('stubs/README.md', .zlib)
 	files << $embed_file('stubs/attributes/Deprecated.v', .zlib)
 	files << $embed_file('stubs/attributes/Table.v', .zlib)
 	files << $embed_file('stubs/attributes/Attribute.v', .zlib)
@@ -49,7 +47,6 @@ pub fn embed_fs() EmbedFS {
 	files << $embed_file('stubs/c_decl.v', .zlib)
 	files << $embed_file('stubs/errors.v', .zlib)
 	files << $embed_file('stubs/threads.v', .zlib)
-	files << $embed_file('v.mod', .zlib)
 
 	return EmbedFS{
 		files: files


### PR DESCRIPTION
The PR restores the functionality of the version command to its state before a regression after eae3f91.
A test to verify the version and to help to prevent further regression is added.