### PR TITLE
ci: add concurrency config

### DIFF
--- a/.github/workflows/analyzer_tests.yml
+++ b/.github/workflows/analyzer_tests.yml
@@ -14,6 +14,10 @@ on:
       - 'editors/code/**'
       - '**/*.md'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}
+  cancel-in-progress: true
+
 jobs:
   test:
     strategy:

--- a/.github/workflows/build_ci.yml
+++ b/.github/workflows/build_ci.yml
@@ -20,6 +20,10 @@ on:
       - '**/test_*.v'
       - '**/*_test.v'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}
+  cancel-in-progress: true
+
 jobs:
   build:
     strategy:

--- a/.github/workflows/install_ci.yml
+++ b/.github/workflows/install_ci.yml
@@ -10,6 +10,10 @@ on:
       - '**/install.vsh'
       - 'install_ci.yml'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}
+  cancel-in-progress: true
+
 jobs:
   install:
     strategy:

--- a/.github/workflows/test_tree_sitter_v.yml
+++ b/.github/workflows/test_tree_sitter_v.yml
@@ -10,6 +10,10 @@ on:
       - 'tree_sitter_v/**'
       - '**/test_tree_sitter_v.yml'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}
+  cancel-in-progress: true
+
 jobs:
   test:
     name: Test tree-sitter

--- a/.github/workflows/vscode_extension_tests.yml
+++ b/.github/workflows/vscode_extension_tests.yml
@@ -10,6 +10,10 @@ on:
       - 'editors/code/**'
       - '**/vscode_extension_tests.yml'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}
+  cancel-in-progress: true
+
 jobs:
   test:
     strategy:


### PR DESCRIPTION
Adds a concurrency config to the workflows except the release workflow to prevent high occupation and delay of runners on repeated pushes to PRs.