### PR TITLE
chore: don't label tree_sitter_v as vendored in `.gitattributes`

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -5,5 +5,3 @@
 **/*.vv linguist-language=V
 **/*.vsh linguist-language=V
 **/v.mod linguist-language=V
-
-tree_sitter_v/** linguist-vendored


### PR DESCRIPTION
Removes the `vendored` label from tree_sitter_v. The module is a part of the project that is actively developed inside the project and not really something "vendored". The tree_sitter_v module has it's own `.gitattributes` file that excludes generated code.

It would result in the following
![Screenshot_20240326_192859](https://github.com/vlang/v-analyzer/assets/34311583/5d9659d2-611d-4196-b670-2547e8b6f138)

Imho it's preferable to display the linguistics of the code base like this.
