### PR TITLE
tree-sitter: rewrite comment grammar, detach line- and block comments

### DIFF
--- a/src/analyzer/psi/Comment.v
+++ b/src/analyzer/psi/Comment.v
@@ -1,5 +1,9 @@
 module psi
 
-pub struct Comment {
+pub struct LineComment {
+	PsiElementImpl
+}
+
+pub struct BlockComment {
 	PsiElementImpl
 }

--- a/src/analyzer/psi/EnumFieldDeclaration.v
+++ b/src/analyzer/psi/EnumFieldDeclaration.v
@@ -19,7 +19,7 @@ pub fn (f &EnumFieldDeclaration) doc_comment() string {
 		return stub.comment
 	}
 
-	if comment := f.find_child_by_type(.comment) {
+	if comment := f.find_child_by_type(.line_comment) {
 		return comment.get_text().trim_string_left('//').trim(' \t')
 	}
 

--- a/src/analyzer/psi/FieldDeclaration.v
+++ b/src/analyzer/psi/FieldDeclaration.v
@@ -26,7 +26,7 @@ pub fn (f &FieldDeclaration) doc_comment() string {
 		return stub.comment
 	}
 
-	if comment := f.find_child_by_type(.comment) {
+	if comment := f.find_child_by_type(.line_comment) {
 		return comment.get_text().trim_string_left('//').trim(' \t')
 	}
 

--- a/src/analyzer/psi/doc_comment_extractor.v
+++ b/src/analyzer/psi/doc_comment_extractor.v
@@ -5,13 +5,13 @@ import strings
 pub fn extract_doc_comment(el PsiElement) string {
 	el_start_line := el.node.start_point().row
 	mut comment := el.prev_sibling() or { return '' }
-	if comment !is Comment {
+	if comment !is LineComment {
 		comment = comment.prev_sibling() or { return '' }
 	}
 
 	mut comments := []PsiElement{}
 
-	for comment is Comment {
+	for comment is LineComment {
 		comment_start_line := comment.node.start_point().row
 
 		if comment_start_line + 1 + u32(comments.len) != el_start_line {
@@ -29,7 +29,7 @@ pub fn extract_doc_comment(el PsiElement) string {
 	mut field_eol_comment := ''
 	if el is FieldDeclaration {
 		if next := el.next_sibling() {
-			if next is Comment {
+			if next is LineComment {
 				comment_start_line := next.node.start_point().row
 				if comment_start_line == el_start_line {
 					field_eol_comment = next.get_text().trim_string_left('//').trim_space()

--- a/src/analyzer/psi/element_factory.v
+++ b/src/analyzer/psi/element_factory.v
@@ -194,8 +194,14 @@ pub fn create_element(node AstNode, containing_file &PsiFile) PsiElement {
 		}
 	}
 
-	if node.type_name == .comment {
-		return Comment{
+	if node.type_name == .line_comment {
+		return LineComment{
+			PsiElementImpl: base_node
+		}
+	}
+
+	if node.type_name == .block_comment {
+		return BlockComment{
 			PsiElementImpl: base_node
 		}
 	}

--- a/tree_sitter_v/bindings/node_types.v
+++ b/tree_sitter_v/bindings/node_types.v
@@ -31,6 +31,7 @@ pub enum NodeType {
 	attributes
 	binary_expression
 	block
+	block_comment
 	break_statement
 	c_string_literal
 	call_expression
@@ -92,6 +93,7 @@ pub enum NodeType {
 	label_definition
 	label_reference
 	labeled_statement
+	line_comment
 	literal
 	literal_attribute
 	lock_expression
@@ -139,6 +141,7 @@ pub enum NodeType {
 	selector_expression
 	send_statement
 	shared_type
+	shebang
 	short_element_list
 	short_lambda
 	signature
@@ -171,7 +174,6 @@ pub enum NodeType {
 	var_definition_list
 	visibility_modifiers
 	wrong_pointer_type
-	comment
 	escape_sequence
 	false_
 	float_literal
@@ -182,7 +184,6 @@ pub enum NodeType {
 	none_
 	pseudo_compile_time_identifier
 	rune_literal
-	shebang
 	true_
 }
 
@@ -341,6 +342,7 @@ const node_type_name_to_enum = {
 	'attributes':                       NodeType.attributes
 	'binary_expression':                NodeType.binary_expression
 	'block':                            NodeType.block
+	'block_comment':                    NodeType.block_comment
 	'break_statement':                  NodeType.break_statement
 	'c_string_literal':                 NodeType.c_string_literal
 	'call_expression':                  NodeType.call_expression
@@ -402,6 +404,7 @@ const node_type_name_to_enum = {
 	'label_definition':                 NodeType.label_definition
 	'label_reference':                  NodeType.label_reference
 	'labeled_statement':                NodeType.labeled_statement
+	'line_comment':                     NodeType.line_comment
 	'literal':                          NodeType.literal
 	'literal_attribute':                NodeType.literal_attribute
 	'lock_expression':                  NodeType.lock_expression
@@ -449,6 +452,7 @@ const node_type_name_to_enum = {
 	'selector_expression':              NodeType.selector_expression
 	'send_statement':                   NodeType.send_statement
 	'shared_type':                      NodeType.shared_type
+	'shebang':                          NodeType.shebang
 	'short_element_list':               NodeType.short_element_list
 	'short_lambda':                     NodeType.short_lambda
 	'signature':                        NodeType.signature
@@ -481,7 +485,6 @@ const node_type_name_to_enum = {
 	'var_definition_list':              NodeType.var_definition_list
 	'visibility_modifiers':             NodeType.visibility_modifiers
 	'wrong_pointer_type':               NodeType.wrong_pointer_type
-	'comment':                          NodeType.comment
 	'escape_sequence':                  NodeType.escape_sequence
 	'false':                            NodeType.false_
 	'float_literal':                    NodeType.float_literal
@@ -492,6 +495,5 @@ const node_type_name_to_enum = {
 	'none':                             NodeType.none_
 	'pseudo_compile_time_identifier':   NodeType.pseudo_compile_time_identifier
 	'rune_literal':                     NodeType.rune_literal
-	'shebang':                          NodeType.shebang
 	'true':                             NodeType.true_
 }

--- a/tree_sitter_v/grammar.js
+++ b/tree_sitter_v/grammar.js
@@ -84,7 +84,7 @@ const list_separator = choice(semi, ',');
 module.exports = grammar({
 	name: 'v',
 
-	extras: ($) => [$.comment, /\s/],
+	extras: ($) => [/\s/, $.line_comment, $.block_comment],
 
 	word: ($) => $.identifier,
 
@@ -126,15 +126,11 @@ module.exports = grammar({
 
 		shebang: (_) => token(/\#\!([^\\\r\n]+)+/),
 
-		// http://stackoverflow.com/questions/13014947/regex-to-match-a-c-style-multiline-comment/36328890#36328890
-		comment: (_) =>
-			token(
-				choice(
-					/\/\/[^\n\r]*/,
-					/\/\*(?:[^\/][^\*]+\/\*+[^\/][^\*]+)+(?:[^\*][^\/]+\*+\/[^\*][^\/]+)+\//,
-					/\/\*[^\*]*\*\//,
-				),
-			),
+		line_comment: ($) => seq('//', /.*/),
+
+		block_comment: ($) => seq('/*', optional(repeat(/([^*]|\/[^/])/)), '*/'),
+
+		comment: ($) => choice($.line_comment, $.block_comment),
 
 		module_clause: ($) => seq(optional($.attributes), 'module', $.identifier),
 

--- a/tree_sitter_v/grammar.js
+++ b/tree_sitter_v/grammar.js
@@ -124,11 +124,16 @@ module.exports = grammar({
 				),
 			),
 
-		shebang: (_) => token(/\#\!([^\\\r\n]+)+/),
+		shebang: (_) => seq('#!', /.*/),
 
-		line_comment: ($) => seq('//', /.*/),
+		line_comment: (_) => seq('//', /.*/),
 
-		block_comment: ($) => seq('/*', optional(repeat(/([^*]|\/[^/])/)), '*/'),
+		block_comment: (_) =>
+			seq(
+				'/*',
+				token(choice(/(?:[^/][^*]+\/\*+[^/][^*]+)+(?:[^*][^/]+\*+\/[^*][^/]+)+/, /[^*]*\*/)),
+				'/',
+			),
 
 		comment: ($) => choice($.line_comment, $.block_comment),
 

--- a/tree_sitter_v/queries/helix.highlights.scm
+++ b/tree_sitter_v/queries/helix.highlights.scm
@@ -1,5 +1,6 @@
 [
- (comment)
+ (line_comment)
+ (block_comment)
  (shebang)
 ] @comment
 

--- a/tree_sitter_v/queries/highlights.scm
+++ b/tree_sitter_v/queries/highlights.scm
@@ -1,7 +1,8 @@
 (ERROR) @error
 
 [
- (comment)
+ (line_comment)
+ (block_comment)
  (shebang)
 ] @comment
 

--- a/tree_sitter_v/src/grammar.json
+++ b/tree_sitter_v/src/grammar.json
@@ -120,31 +120,72 @@
       ]
     },
     "shebang": {
-      "type": "TOKEN",
-      "content": {
-        "type": "PATTERN",
-        "value": "\\#\\!([^\\\\\\r\\n]+)+"
-      }
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "STRING",
+          "value": "#!"
+        },
+        {
+          "type": "PATTERN",
+          "value": ".*"
+        }
+      ]
+    },
+    "line_comment": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "STRING",
+          "value": "//"
+        },
+        {
+          "type": "PATTERN",
+          "value": ".*"
+        }
+      ]
+    },
+    "block_comment": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "STRING",
+          "value": "/*"
+        },
+        {
+          "type": "TOKEN",
+          "content": {
+            "type": "CHOICE",
+            "members": [
+              {
+                "type": "PATTERN",
+                "value": "(?:[^/][^*]+\\/\\*+[^/][^*]+)+(?:[^*][^/]+\\*+\\/[^*][^/]+)+"
+              },
+              {
+                "type": "PATTERN",
+                "value": "[^*]*\\*"
+              }
+            ]
+          }
+        },
+        {
+          "type": "STRING",
+          "value": "/"
+        }
+      ]
     },
     "comment": {
-      "type": "TOKEN",
-      "content": {
-        "type": "CHOICE",
-        "members": [
-          {
-            "type": "PATTERN",
-            "value": "\\/\\/[^\\n\\r]*"
-          },
-          {
-            "type": "PATTERN",
-            "value": "\\/\\*(?:[^\\/][^\\*]+\\/\\*+[^\\/][^\\*]+)+(?:[^\\*][^\\/]+\\*+\\/[^\\*][^\\/]+)+\\/"
-          },
-          {
-            "type": "PATTERN",
-            "value": "\\/\\*[^\\*]*\\*\\/"
-          }
-        ]
-      }
+      "type": "CHOICE",
+      "members": [
+        {
+          "type": "SYMBOL",
+          "name": "line_comment"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "block_comment"
+        }
+      ]
     },
     "module_clause": {
       "type": "SEQ",
@@ -8530,12 +8571,16 @@
   },
   "extras": [
     {
-      "type": "SYMBOL",
-      "name": "comment"
-    },
-    {
       "type": "PATTERN",
       "value": "\\s"
+    },
+    {
+      "type": "SYMBOL",
+      "name": "line_comment"
+    },
+    {
+      "type": "SYMBOL",
+      "name": "block_comment"
     }
   ],
   "conflicts": [

--- a/tree_sitter_v/src/node-types.json
+++ b/tree_sitter_v/src/node-types.json
@@ -748,6 +748,11 @@
     }
   },
   {
+    "type": "block_comment",
+    "named": true,
+    "fields": {}
+  },
+  {
     "type": "break_statement",
     "named": true,
     "fields": {},
@@ -2221,6 +2226,11 @@
     }
   },
   {
+    "type": "line_comment",
+    "named": true,
+    "fields": {}
+  },
+  {
     "type": "literal",
     "named": true,
     "fields": {},
@@ -3384,6 +3394,11 @@
     }
   },
   {
+    "type": "shebang",
+    "named": true,
+    "fields": {}
+  },
+  {
     "type": "short_element_list",
     "named": true,
     "fields": {},
@@ -4347,6 +4362,10 @@
     "named": false
   },
   {
+    "type": "#!",
+    "named": false
+  },
+  {
     "type": "#[",
     "named": false
   },
@@ -4452,6 +4471,14 @@
   },
   {
     "type": "/",
+    "named": false
+  },
+  {
+    "type": "/*",
+    "named": false
+  },
+  {
+    "type": "//",
     "named": false
   },
   {
@@ -4581,10 +4608,6 @@
   {
     "type": "chan",
     "named": false
-  },
-  {
-    "type": "comment",
-    "named": true
   },
   {
     "type": "const",
@@ -4729,10 +4752,6 @@
   {
     "type": "shared",
     "named": false
-  },
-  {
-    "type": "shebang",
-    "named": true
   },
   {
     "type": "spawn",

--- a/tree_sitter_v/test/corpus/comments.txt
+++ b/tree_sitter_v/test/corpus/comments.txt
@@ -7,8 +7,8 @@ module foo
 --------------------------------------------------------------------------------
 
 (source_file
-  (comment)
-  (comment)
+  (line_comment)
+  (block_comment)
   (module_clause
     (identifier)))
 
@@ -21,8 +21,8 @@ module foo
 --------------------------------------------------------------------------------
 
 (source_file
-  (comment)
-  (comment)
+  (line_comment)
+  (line_comment)
   (module_clause
     (identifier)))
 
@@ -37,7 +37,7 @@ module foo
 --------------------------------------------------------------------------------
 
 (source_file
-  (comment)
+  (block_comment)
   (module_clause
     (identifier)))
 
@@ -69,8 +69,8 @@ module foo
 --------------------------------------------------------------------------------
 
 (source_file
-  (comment)
-  (comment)
+  (block_comment)
+  (line_comment)
   (module_clause
     (identifier))
-  (comment))
+  (block_comment))

--- a/tree_sitter_v/test/corpus/function_declaration.txt
+++ b/tree_sitter_v/test/corpus/function_declaration.txt
@@ -427,7 +427,7 @@ fn foo() {}
 --------------------------------------------------------------------------------
 
 (source_file
-  (comment)
+  (line_comment)
   (function_declaration
     (attributes
       (attribute
@@ -535,7 +535,7 @@ pub fn C.foo[T, U, ](foo string, age ...int) !(int, string, ) {}
 --------------------------------------------------------------------------------
 
 (source_file
-  (comment)
+  (line_comment)
   (function_declaration
     (attributes
       (attribute

--- a/tree_sitter_v/test/corpus/interface_declaration.txt
+++ b/tree_sitter_v/test/corpus/interface_declaration.txt
@@ -198,7 +198,7 @@ interface Foo {
 --------------------------------------------------------------------------------
 
 (source_file
-  (comment)
+  (line_comment)
   (interface_declaration
     (attributes
       (attribute

--- a/tree_sitter_v/test/corpus/is_as_expression.txt
+++ b/tree_sitter_v/test/corpus/is_as_expression.txt
@@ -197,7 +197,7 @@ fn test_parse_compact_text() {
 --------------------------------------------------------------------------------
 
 (source_file
-  (comment)
+  (line_comment)
   (function_declaration
     (visibility_modifiers)
     (receiver
@@ -694,8 +694,8 @@ fn test_parse_compact_text() {
                           (identifier))
                         (type_reference_expression
                           (identifier)))))))))))
-      (comment)
-      (comment)
+      (line_comment)
+      (line_comment)
       (simple_statement
         (var_declaration
           (expression_list

--- a/tree_sitter_v/test/corpus/module_clause.txt
+++ b/tree_sitter_v/test/corpus/module_clause.txt
@@ -17,8 +17,8 @@ module main
 --------------------------------------------------------------------------------
 
 (source_file
-  (comment)
-  (comment)
+  (line_comment)
+  (line_comment)
   (module_clause
     (identifier)))
 
@@ -49,8 +49,8 @@ module main
 --------------------------------------------------------------------------------
 
 (source_file
-  (comment)
-  (comment)
+  (line_comment)
+  (line_comment)
   (module_clause
     (attributes
       (attribute

--- a/tree_sitter_v/test/corpus/select_expression.txt
+++ b/tree_sitter_v/test/corpus/select_expression.txt
@@ -173,9 +173,9 @@ if select {
               (reference_expression
                 (identifier))))
           (block
-            (comment))))
+            (line_comment))))
       (block
-        (comment))
+        (line_comment))
       (else_branch
         (block
-          (comment))))))
+          (line_comment))))))

--- a/tree_sitter_v/test/corpus/struct_declaration.txt
+++ b/tree_sitter_v/test/corpus/struct_declaration.txt
@@ -95,7 +95,7 @@ struct Foo {
 --------------------------------------------------------------------------------
 
 (source_file
-  (comment)
+  (line_comment)
   (struct_declaration
     (attributes
       (attribute

--- a/tree_sitter_v/test/corpus/type_declaration.txt
+++ b/tree_sitter_v/test/corpus/type_declaration.txt
@@ -186,4 +186,7 @@ type Height =
     (plain_type
       (type_reference_expression
         (identifier))))
-  (ERROR))
+  (ERROR
+    (plain_type
+      (type_reference_expression
+        (MISSING identifier)))))


### PR DESCRIPTION
Detaches line and block comments. E.g. when extracting doc comments analyzer can now differentiate for LineComments