### PR TITLE
tree-sitter: further improve parsing of nested comments, extend tests

### DIFF
--- a/tree_sitter_v/bindings/node_types.v
+++ b/tree_sitter_v/bindings/node_types.v
@@ -31,6 +31,7 @@ pub enum NodeType {
 	attributes
 	binary_expression
 	block
+	block_comment
 	break_statement
 	c_string_literal
 	call_expression
@@ -173,7 +174,6 @@ pub enum NodeType {
 	var_definition_list
 	visibility_modifiers
 	wrong_pointer_type
-	block_comment
 	escape_sequence
 	false_
 	float_literal
@@ -342,6 +342,7 @@ const node_type_name_to_enum = {
 	'attributes':                       NodeType.attributes
 	'binary_expression':                NodeType.binary_expression
 	'block':                            NodeType.block
+	'block_comment':                    NodeType.block_comment
 	'break_statement':                  NodeType.break_statement
 	'c_string_literal':                 NodeType.c_string_literal
 	'call_expression':                  NodeType.call_expression
@@ -484,7 +485,6 @@ const node_type_name_to_enum = {
 	'var_definition_list':              NodeType.var_definition_list
 	'visibility_modifiers':             NodeType.visibility_modifiers
 	'wrong_pointer_type':               NodeType.wrong_pointer_type
-	'block_comment':                    NodeType.block_comment
 	'escape_sequence':                  NodeType.escape_sequence
 	'false':                            NodeType.false_
 	'float_literal':                    NodeType.float_literal

--- a/tree_sitter_v/bindings/node_types.v
+++ b/tree_sitter_v/bindings/node_types.v
@@ -31,7 +31,6 @@ pub enum NodeType {
 	attributes
 	binary_expression
 	block
-	block_comment
 	break_statement
 	c_string_literal
 	call_expression
@@ -174,6 +173,7 @@ pub enum NodeType {
 	var_definition_list
 	visibility_modifiers
 	wrong_pointer_type
+	block_comment
 	escape_sequence
 	false_
 	float_literal
@@ -342,7 +342,6 @@ const node_type_name_to_enum = {
 	'attributes':                       NodeType.attributes
 	'binary_expression':                NodeType.binary_expression
 	'block':                            NodeType.block
-	'block_comment':                    NodeType.block_comment
 	'break_statement':                  NodeType.break_statement
 	'c_string_literal':                 NodeType.c_string_literal
 	'call_expression':                  NodeType.call_expression
@@ -485,6 +484,7 @@ const node_type_name_to_enum = {
 	'var_definition_list':              NodeType.var_definition_list
 	'visibility_modifiers':             NodeType.visibility_modifiers
 	'wrong_pointer_type':               NodeType.wrong_pointer_type
+	'block_comment':                    NodeType.block_comment
 	'escape_sequence':                  NodeType.escape_sequence
 	'false':                            NodeType.false_
 	'float_literal':                    NodeType.float_literal

--- a/tree_sitter_v/grammar.js
+++ b/tree_sitter_v/grammar.js
@@ -128,16 +128,20 @@ module.exports = grammar({
 
 		line_comment: (_) => seq('//', /.*/),
 
-		block_comment: ($) =>
-			token(
-				seq(
-					'/*',
+		block_comment: (_) =>
+			seq(
+				'/*',
+				repeat(
 					choice(
-						/[^*]*\*+([^/*][^*]*\*+)*/, // Block comment body.
-						/(?:[^/][^*]+\/\*+[^/][^*]+)+(?:[^*][^/]+\*+\/[^*][^/]+)+/, // Nested block comment body.
+						/\*/,
+						regexOr(
+							'[^*]', // any symbol except reserved
+							'[/][^*]', // start of nested comment
+							'[^*][/]', // end of nested comment
+						),
 					),
-					'/',
 				),
+				'*/',
 			),
 
 		comment: ($) => choice($.line_comment, $.block_comment),
@@ -1332,4 +1336,17 @@ function comma_sep1(rules) {
  */
 function comma_sep(rule) {
 	return optional(comma_sep1(rule));
+}
+
+/**
+ * @param {...string} args - One or more regular expression patterns.
+ *
+ * @return {PatternRule}
+ */
+function regexOr(...args) {
+	const regex = args.length > 1 ? args.join('|') : args[0];
+	return {
+		type: 'PATTERN',
+		value: regex,
+	};
 }

--- a/tree_sitter_v/grammar.js
+++ b/tree_sitter_v/grammar.js
@@ -128,11 +128,16 @@ module.exports = grammar({
 
 		line_comment: (_) => seq('//', /.*/),
 
-		block_comment: (_) =>
-			seq(
-				'/*',
-				token(choice(/(?:[^/][^*]+\/\*+[^/][^*]+)+(?:[^*][^/]+\*+\/[^*][^/]+)+/, /[^*]*\*/)),
-				'/',
+		block_comment: ($) =>
+			token(
+				seq(
+					'/*',
+					choice(
+						/[^*]*.*\*/, // Block comment body.
+						/(?:[^/][^*]+\/\*+[^/][^*]+)+(?:[^*][^/]+\*+\/[^*][^/]+)+/, // Nested block comment body.
+					),
+					'/',
+				),
 			),
 
 		comment: ($) => choice($.line_comment, $.block_comment),

--- a/tree_sitter_v/grammar.js
+++ b/tree_sitter_v/grammar.js
@@ -133,7 +133,7 @@ module.exports = grammar({
 				seq(
 					'/*',
 					choice(
-						/[^*]*.*\*/, // Block comment body.
+						/[^*]*\*+([^/*][^*]*\*+)*/, // Block comment body.
 						/(?:[^/][^*]+\/\*+[^/][^*]+)+(?:[^*][^/]+\*+\/[^*][^/]+)+/, // Nested block comment body.
 					),
 					'/',

--- a/tree_sitter_v/src/grammar.json
+++ b/tree_sitter_v/src/grammar.json
@@ -146,33 +146,33 @@
       ]
     },
     "block_comment": {
-      "type": "SEQ",
-      "members": [
-        {
-          "type": "STRING",
-          "value": "/*"
-        },
-        {
-          "type": "TOKEN",
-          "content": {
+      "type": "TOKEN",
+      "content": {
+        "type": "SEQ",
+        "members": [
+          {
+            "type": "STRING",
+            "value": "/*"
+          },
+          {
             "type": "CHOICE",
             "members": [
               {
                 "type": "PATTERN",
-                "value": "(?:[^/][^*]+\\/\\*+[^/][^*]+)+(?:[^*][^/]+\\*+\\/[^*][^/]+)+"
+                "value": "[^*]*.*\\*"
               },
               {
                 "type": "PATTERN",
-                "value": "[^*]*\\*"
+                "value": "(?:[^/][^*]+\\/\\*+[^/][^*]+)+(?:[^*][^/]+\\*+\\/[^*][^/]+)+"
               }
             ]
+          },
+          {
+            "type": "STRING",
+            "value": "/"
           }
-        },
-        {
-          "type": "STRING",
-          "value": "/"
-        }
-      ]
+        ]
+      }
     },
     "comment": {
       "type": "CHOICE",

--- a/tree_sitter_v/src/grammar.json
+++ b/tree_sitter_v/src/grammar.json
@@ -146,33 +146,33 @@
       ]
     },
     "block_comment": {
-      "type": "TOKEN",
-      "content": {
-        "type": "SEQ",
-        "members": [
-          {
-            "type": "STRING",
-            "value": "/*"
-          },
-          {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "STRING",
+          "value": "/*"
+        },
+        {
+          "type": "REPEAT",
+          "content": {
             "type": "CHOICE",
             "members": [
               {
                 "type": "PATTERN",
-                "value": "[^*]*.*\\*"
+                "value": "\\*"
               },
               {
                 "type": "PATTERN",
-                "value": "(?:[^/][^*]+\\/\\*+[^/][^*]+)+(?:[^*][^/]+\\*+\\/[^*][^/]+)+"
+                "value": "[^*]|[/][^*]|[^*][/]"
               }
             ]
-          },
-          {
-            "type": "STRING",
-            "value": "/"
           }
-        ]
-      }
+        },
+        {
+          "type": "STRING",
+          "value": "*/"
+        }
+      ]
     },
     "comment": {
       "type": "CHOICE",

--- a/tree_sitter_v/src/node-types.json
+++ b/tree_sitter_v/src/node-types.json
@@ -748,6 +748,11 @@
     }
   },
   {
+    "type": "block_comment",
+    "named": true,
+    "fields": {}
+  },
+  {
     "type": "break_statement",
     "named": true,
     "fields": {},
@@ -4421,6 +4426,10 @@
     "named": false
   },
   {
+    "type": "*/",
+    "named": false
+  },
+  {
     "type": "*=",
     "named": false
   },
@@ -4466,6 +4475,10 @@
   },
   {
     "type": "/",
+    "named": false
+  },
+  {
+    "type": "/*",
     "named": false
   },
   {
@@ -4591,10 +4604,6 @@
   {
     "type": "atomic",
     "named": false
-  },
-  {
-    "type": "block_comment",
-    "named": true
   },
   {
     "type": "break",

--- a/tree_sitter_v/src/node-types.json
+++ b/tree_sitter_v/src/node-types.json
@@ -748,11 +748,6 @@
     }
   },
   {
-    "type": "block_comment",
-    "named": true,
-    "fields": {}
-  },
-  {
     "type": "break_statement",
     "named": true,
     "fields": {},
@@ -4474,10 +4469,6 @@
     "named": false
   },
   {
-    "type": "/*",
-    "named": false
-  },
-  {
     "type": "//",
     "named": false
   },
@@ -4600,6 +4591,10 @@
   {
     "type": "atomic",
     "named": false
+  },
+  {
+    "type": "block_comment",
+    "named": true
   },
   {
     "type": "break",

--- a/tree_sitter_v/test/corpus/comments.txt
+++ b/tree_sitter_v/test/corpus/comments.txt
@@ -3,11 +3,13 @@ Empty comment
 ================================================================================
 //
 /**/
+/***/
 module foo
 --------------------------------------------------------------------------------
 
 (source_file
   (line_comment)
+  (block_comment)
   (block_comment)
   (module_clause
     (identifier)))
@@ -33,45 +35,44 @@ Multiline comment
   Multiline comment
   Multiline comment
 */
-/**foo**/
 /*foo**/
-/**foo*/
 module foo
+/**foo*/
+/**foo**/
 --------------------------------------------------------------------------------
 
 (source_file
   (block_comment)
   (block_comment)
-  (block_comment)
-  (block_comment)
   (module_clause
-    (identifier)))
+    (identifier))
+  (block_comment)
+  (block_comment))
 
 ================================================================================
 Multiline nested comment
 ================================================================================
-/*
-  /* Nested with ending asterisks **/
-
-  /** Nested with starting asterisks */
-
-  /* Nested */
-*/
-// comment /* comment */
-module foo
-/*
-  Multiline
+/**********************************************************************
+* Comment
+* /*** Nested ***/
+**********************************************************************/
+module main
+/* Recuresively nested
+  > Level 1
   /*
-    Multiline
+    >> Level 2
     /*
 
+      >>> Level 3
       /* Nested */
-      Multiline
+      <<<
     */
-    Multiline
+    <<
   */
-  Multiline
+  <
 */
+foo := 'abc'
+/* asdf */
 --------------------------------------------------------------------------------
 
 (source_file
@@ -79,4 +80,12 @@ module foo
   (line_comment)
   (module_clause
     (identifier))
-  (block_comment))
+  (block_comment)
+  (simple_statement
+    (var_declaration
+      (expression_list
+        (reference_expression
+          (identifier)))
+      (expression_list
+        (literal
+          (interpreted_string_literal))))))

--- a/tree_sitter_v/test/corpus/comments.txt
+++ b/tree_sitter_v/test/corpus/comments.txt
@@ -33,10 +33,16 @@ Multiline comment
   Multiline comment
   Multiline comment
 */
+/**foo**/
+/*foo**/
+/**foo*/
 module foo
 --------------------------------------------------------------------------------
 
 (source_file
+  (block_comment)
+  (block_comment)
+  (block_comment)
   (block_comment)
   (module_clause
     (identifier)))
@@ -45,26 +51,26 @@ module foo
 Multiline nested comment
 ================================================================================
 /*
-  /* Nested */
-  Multiline comment
-  /* Nested */
-  Multiline comment
+  /* Nested with ending asterisks **/
+
+  /** Nested with starting asterisks */
+
   /* Nested */
 */
 // comment /* comment */
 module foo
 /*
-  Multiline comment
+  Multiline
   /*
-    Multiline comment
+    Multiline
     /*
-      Multiline comment
+
       /* Nested */
-      Multiline comment
+      Multiline
     */
-    Multiline comment
+    Multiline
   */
-  Multiline comment
+  Multiline
 */
 --------------------------------------------------------------------------------
 

--- a/tree_sitter_v/test/corpus/comments.txt
+++ b/tree_sitter_v/test/corpus/comments.txt
@@ -52,10 +52,14 @@ module foo
 ================================================================================
 Multiline nested comment
 ================================================================================
-/**********************************************************************
-* Comment
-* /*** Nested ***/
-**********************************************************************/
+/*
+  /* Nested with ending asterisks **/
+
+  /** Nested with starting asterisks */
+
+  /* Nested */
+*/
+// comment /* comment */
 module main
 /* Recuresively nested
   > Level 1
@@ -72,15 +76,24 @@ module main
   <
 */
 foo := 'abc'
-/* asdf */
+/**********************************************************************
+* Comment
+* /*** Nested ***/
+**********************************************************************/
 --------------------------------------------------------------------------------
 
 (source_file
-  (block_comment)
+  (block_comment
+    (block_comment)
+    (block_comment)
+    (block_comment))
   (line_comment)
   (module_clause
     (identifier))
-  (block_comment)
+  (block_comment
+    (block_comment
+      (block_comment
+        (block_comment))))
   (simple_statement
     (var_declaration
       (expression_list
@@ -88,4 +101,6 @@ foo := 'abc'
           (identifier)))
       (expression_list
         (literal
-          (interpreted_string_literal))))))
+          (interpreted_string_literal)))))
+  (block_comment
+    (block_comment)))


### PR DESCRIPTION
There are still several cases where comment parsing might run into errors. This PR approaches to fix some of them and to extend tests.