### PR TITLE
tree-sitter: fix parser error on unescaped dollar identifier in string literals, add test

### DIFF
--- a/tree_sitter_v/bindings/node_types.v
+++ b/tree_sitter_v/bindings/node_types.v
@@ -85,7 +85,6 @@ pub enum NodeType {
 	index_expression
 	interface_declaration
 	interface_method_definition
-	interpolation_closing
 	interpreted_string_literal
 	is_clause
 	is_expression
@@ -178,6 +177,7 @@ pub enum NodeType {
 	float_literal
 	identifier
 	int_literal
+	interpolation_closing
 	interpolation_opening
 	nil_
 	none_
@@ -393,7 +393,6 @@ const node_type_name_to_enum = {
 	'index_expression':                 NodeType.index_expression
 	'interface_declaration':            NodeType.interface_declaration
 	'interface_method_definition':      NodeType.interface_method_definition
-	'interpolation_closing':            NodeType.interpolation_closing
 	'interpreted_string_literal':       NodeType.interpreted_string_literal
 	'is_clause':                        NodeType.is_clause
 	'is_expression':                    NodeType.is_expression
@@ -486,6 +485,7 @@ const node_type_name_to_enum = {
 	'float_literal':                    NodeType.float_literal
 	'identifier':                       NodeType.identifier
 	'int_literal':                      NodeType.int_literal
+	'interpolation_closing':            NodeType.interpolation_closing
 	'interpolation_opening':            NodeType.interpolation_opening
 	'nil':                              NodeType.nil_
 	'none':                             NodeType.none_

--- a/tree_sitter_v/grammar.js
+++ b/tree_sitter_v/grammar.js
@@ -1251,7 +1251,7 @@ function sep(rule) {
  *
  */
 function stringBody(re, $) {
-	return choice(token.immediate(prec.right(1, re)), $.escape_sequence, $.string_interpolation);
+	return choice(token.immediate(prec.right(1, re)), '$', $.escape_sequence, $.string_interpolation);
 }
 
 /**

--- a/tree_sitter_v/src/grammar.json
+++ b/tree_sitter_v/src/grammar.json
@@ -1307,35 +1307,27 @@
           "value": "("
         },
         {
-          "type": "CHOICE",
+          "type": "SEQ",
           "members": [
             {
-              "type": "SEQ",
-              "members": [
-                {
-                  "type": "SYMBOL",
-                  "name": "type_parameter_declaration"
-                },
-                {
-                  "type": "REPEAT",
-                  "content": {
-                    "type": "SEQ",
-                    "members": [
-                      {
-                        "type": "STRING",
-                        "value": ","
-                      },
-                      {
-                        "type": "SYMBOL",
-                        "name": "type_parameter_declaration"
-                      }
-                    ]
-                  }
-                }
-              ]
+              "type": "SYMBOL",
+              "name": "type_parameter_declaration"
             },
             {
-              "type": "BLANK"
+              "type": "REPEAT",
+              "content": {
+                "type": "SEQ",
+                "members": [
+                  {
+                    "type": "STRING",
+                    "value": ","
+                  },
+                  {
+                    "type": "SYMBOL",
+                    "name": "type_parameter_declaration"
+                  }
+                ]
+              }
             }
           ]
         },
@@ -3187,35 +3179,27 @@
           "value": "["
         },
         {
-          "type": "CHOICE",
+          "type": "SEQ",
           "members": [
             {
-              "type": "SEQ",
-              "members": [
-                {
-                  "type": "SYMBOL",
-                  "name": "capture"
-                },
-                {
-                  "type": "REPEAT",
-                  "content": {
-                    "type": "SEQ",
-                    "members": [
-                      {
-                        "type": "STRING",
-                        "value": ","
-                      },
-                      {
-                        "type": "SYMBOL",
-                        "name": "capture"
-                      }
-                    ]
-                  }
-                }
-              ]
+              "type": "SYMBOL",
+              "name": "capture"
             },
             {
-              "type": "BLANK"
+              "type": "REPEAT",
+              "content": {
+                "type": "SEQ",
+                "members": [
+                  {
+                    "type": "STRING",
+                    "value": ","
+                  },
+                  {
+                    "type": "SYMBOL",
+                    "name": "capture"
+                  }
+                ]
+              }
             }
           ]
         },
@@ -3615,41 +3599,6 @@
         }
       ]
     },
-    "compile_time_selector_expression": {
-      "type": "SEQ",
-      "members": [
-        {
-          "type": "STRING",
-          "value": "$"
-        },
-        {
-          "type": "SEQ",
-          "members": [
-            {
-              "type": "STRING",
-              "value": "("
-            },
-            {
-              "type": "CHOICE",
-              "members": [
-                {
-                  "type": "SYMBOL",
-                  "name": "reference_expression"
-                },
-                {
-                  "type": "SYMBOL",
-                  "name": "selector_expression"
-                }
-              ]
-            },
-            {
-              "type": "STRING",
-              "value": ")"
-            }
-          ]
-        }
-      ]
-    },
     "or_block": {
       "type": "SEQ",
       "members": [
@@ -4012,6 +3961,39 @@
           ]
         }
       }
+    },
+    "compile_time_selector_expression": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "IMMEDIATE_TOKEN",
+          "content": {
+            "type": "STRING",
+            "value": "$("
+          }
+        },
+        {
+          "type": "FIELD",
+          "name": "field",
+          "content": {
+            "type": "CHOICE",
+            "members": [
+              {
+                "type": "SYMBOL",
+                "name": "reference_expression"
+              },
+              {
+                "type": "SYMBOL",
+                "name": "selector_expression"
+              }
+            ]
+          }
+        },
+        {
+          "type": "STRING",
+          "value": ")"
+        }
+      ]
     },
     "index_expression": {
       "type": "PREC_DYNAMIC",
@@ -6060,258 +6042,262 @@
       "members": [
         {
           "type": "SYMBOL",
+          "name": "interpreted_string_literal"
+        },
+        {
+          "type": "SYMBOL",
           "name": "c_string_literal"
         },
         {
           "type": "SYMBOL",
           "name": "raw_string_literal"
+        }
+      ]
+    },
+    "interpreted_string_literal": {
+      "type": "CHOICE",
+      "members": [
+        {
+          "type": "SEQ",
+          "members": [
+            {
+              "type": "STRING",
+              "value": "'"
+            },
+            {
+              "type": "REPEAT",
+              "content": {
+                "type": "CHOICE",
+                "members": [
+                  {
+                    "type": "IMMEDIATE_TOKEN",
+                    "content": {
+                      "type": "PREC_RIGHT",
+                      "value": 1,
+                      "content": {
+                        "type": "PATTERN",
+                        "value": "[^'\\\\$]+"
+                      }
+                    }
+                  },
+                  {
+                    "type": "STRING",
+                    "value": "$"
+                  },
+                  {
+                    "type": "SYMBOL",
+                    "name": "escape_sequence"
+                  },
+                  {
+                    "type": "SYMBOL",
+                    "name": "string_interpolation"
+                  }
+                ]
+              }
+            },
+            {
+              "type": "STRING",
+              "value": "'"
+            }
+          ]
         },
         {
-          "type": "SYMBOL",
-          "name": "interpreted_string_literal"
+          "type": "SEQ",
+          "members": [
+            {
+              "type": "STRING",
+              "value": "\""
+            },
+            {
+              "type": "REPEAT",
+              "content": {
+                "type": "CHOICE",
+                "members": [
+                  {
+                    "type": "IMMEDIATE_TOKEN",
+                    "content": {
+                      "type": "PREC_RIGHT",
+                      "value": 1,
+                      "content": {
+                        "type": "PATTERN",
+                        "value": "[^\"\\\\$]+"
+                      }
+                    }
+                  },
+                  {
+                    "type": "STRING",
+                    "value": "$"
+                  },
+                  {
+                    "type": "SYMBOL",
+                    "name": "escape_sequence"
+                  },
+                  {
+                    "type": "SYMBOL",
+                    "name": "string_interpolation"
+                  }
+                ]
+              }
+            },
+            {
+              "type": "STRING",
+              "value": "\""
+            }
+          ]
         }
       ]
     },
     "c_string_literal": {
-      "type": "PREC",
-      "value": 1,
-      "content": {
-        "type": "CHOICE",
-        "members": [
-          {
-            "type": "SEQ",
-            "members": [
-              {
-                "type": "SYMBOL",
-                "name": "__c_single_quote"
-              },
-              {
-                "type": "REPEAT",
-                "content": {
-                  "type": "CHOICE",
-                  "members": [
-                    {
-                      "type": "IMMEDIATE_TOKEN",
+      "type": "CHOICE",
+      "members": [
+        {
+          "type": "SEQ",
+          "members": [
+            {
+              "type": "STRING",
+              "value": "c'"
+            },
+            {
+              "type": "REPEAT",
+              "content": {
+                "type": "CHOICE",
+                "members": [
+                  {
+                    "type": "IMMEDIATE_TOKEN",
+                    "content": {
+                      "type": "PREC_RIGHT",
+                      "value": 1,
                       "content": {
-                        "type": "PREC_RIGHT",
-                        "value": 1,
-                        "content": {
-                          "type": "PATTERN",
-                          "value": "[^'\\\\$]+"
-                        }
+                        "type": "PATTERN",
+                        "value": "[^'\\\\$]+"
                       }
-                    },
-                    {
-                      "type": "SYMBOL",
-                      "name": "escape_sequence"
-                    },
-                    {
-                      "type": "SYMBOL",
-                      "name": "string_interpolation"
                     }
-                  ]
-                }
-              },
-              {
-                "type": "SYMBOL",
-                "name": "__single_quote"
+                  },
+                  {
+                    "type": "STRING",
+                    "value": "$"
+                  },
+                  {
+                    "type": "SYMBOL",
+                    "name": "escape_sequence"
+                  },
+                  {
+                    "type": "SYMBOL",
+                    "name": "string_interpolation"
+                  }
+                ]
               }
-            ]
-          },
-          {
-            "type": "SEQ",
-            "members": [
-              {
-                "type": "SYMBOL",
-                "name": "__c_double_quote"
-              },
-              {
-                "type": "REPEAT",
-                "content": {
-                  "type": "CHOICE",
-                  "members": [
-                    {
-                      "type": "IMMEDIATE_TOKEN",
+            },
+            {
+              "type": "STRING",
+              "value": "'"
+            }
+          ]
+        },
+        {
+          "type": "SEQ",
+          "members": [
+            {
+              "type": "STRING",
+              "value": "c\""
+            },
+            {
+              "type": "REPEAT",
+              "content": {
+                "type": "CHOICE",
+                "members": [
+                  {
+                    "type": "IMMEDIATE_TOKEN",
+                    "content": {
+                      "type": "PREC_RIGHT",
+                      "value": 1,
                       "content": {
-                        "type": "PREC_RIGHT",
-                        "value": 1,
-                        "content": {
-                          "type": "PATTERN",
-                          "value": "[^\"\\\\$]+"
-                        }
+                        "type": "PATTERN",
+                        "value": "[^\"\\\\$]+"
                       }
-                    },
-                    {
-                      "type": "SYMBOL",
-                      "name": "escape_sequence"
-                    },
-                    {
-                      "type": "SYMBOL",
-                      "name": "string_interpolation"
                     }
-                  ]
-                }
-              },
-              {
-                "type": "SYMBOL",
-                "name": "__double_quote"
+                  },
+                  {
+                    "type": "STRING",
+                    "value": "$"
+                  },
+                  {
+                    "type": "SYMBOL",
+                    "name": "escape_sequence"
+                  },
+                  {
+                    "type": "SYMBOL",
+                    "name": "string_interpolation"
+                  }
+                ]
               }
-            ]
-          }
-        ]
-      }
+            },
+            {
+              "type": "STRING",
+              "value": "\""
+            }
+          ]
+        }
+      ]
     },
     "raw_string_literal": {
-      "type": "PREC",
-      "value": 1,
-      "content": {
-        "type": "CHOICE",
-        "members": [
-          {
-            "type": "SEQ",
-            "members": [
-              {
-                "type": "SYMBOL",
-                "name": "__r_single_quote"
-              },
-              {
-                "type": "REPEAT",
+      "type": "CHOICE",
+      "members": [
+        {
+          "type": "SEQ",
+          "members": [
+            {
+              "type": "STRING",
+              "value": "r'"
+            },
+            {
+              "type": "REPEAT",
+              "content": {
+                "type": "IMMEDIATE_TOKEN",
                 "content": {
-                  "type": "IMMEDIATE_TOKEN",
+                  "type": "PREC_RIGHT",
+                  "value": 1,
                   "content": {
-                    "type": "PREC_RIGHT",
-                    "value": 1,
-                    "content": {
-                      "type": "PATTERN",
-                      "value": "[^']+"
-                    }
+                    "type": "PATTERN",
+                    "value": "[^']+"
                   }
                 }
-              },
-              {
-                "type": "SYMBOL",
-                "name": "__single_quote"
               }
-            ]
-          },
-          {
-            "type": "SEQ",
-            "members": [
-              {
-                "type": "SYMBOL",
-                "name": "__r_double_quote"
-              },
-              {
-                "type": "REPEAT",
+            },
+            {
+              "type": "STRING",
+              "value": "'"
+            }
+          ]
+        },
+        {
+          "type": "SEQ",
+          "members": [
+            {
+              "type": "STRING",
+              "value": "r\""
+            },
+            {
+              "type": "REPEAT",
+              "content": {
+                "type": "IMMEDIATE_TOKEN",
                 "content": {
-                  "type": "IMMEDIATE_TOKEN",
+                  "type": "PREC_RIGHT",
+                  "value": 1,
                   "content": {
-                    "type": "PREC_RIGHT",
-                    "value": 1,
-                    "content": {
-                      "type": "PATTERN",
-                      "value": "[^\"]+"
-                    }
+                    "type": "PATTERN",
+                    "value": "[^\"]+"
                   }
                 }
-              },
-              {
-                "type": "SYMBOL",
-                "name": "__double_quote"
               }
-            ]
-          }
-        ]
-      }
-    },
-    "interpreted_string_literal": {
-      "type": "PREC",
-      "value": 1,
-      "content": {
-        "type": "CHOICE",
-        "members": [
-          {
-            "type": "SEQ",
-            "members": [
-              {
-                "type": "SYMBOL",
-                "name": "__single_quote"
-              },
-              {
-                "type": "REPEAT",
-                "content": {
-                  "type": "CHOICE",
-                  "members": [
-                    {
-                      "type": "IMMEDIATE_TOKEN",
-                      "content": {
-                        "type": "PREC_RIGHT",
-                        "value": 1,
-                        "content": {
-                          "type": "PATTERN",
-                          "value": "[^'\\\\$]+"
-                        }
-                      }
-                    },
-                    {
-                      "type": "SYMBOL",
-                      "name": "escape_sequence"
-                    },
-                    {
-                      "type": "SYMBOL",
-                      "name": "string_interpolation"
-                    }
-                  ]
-                }
-              },
-              {
-                "type": "SYMBOL",
-                "name": "__single_quote"
-              }
-            ]
-          },
-          {
-            "type": "SEQ",
-            "members": [
-              {
-                "type": "SYMBOL",
-                "name": "__double_quote"
-              },
-              {
-                "type": "REPEAT",
-                "content": {
-                  "type": "CHOICE",
-                  "members": [
-                    {
-                      "type": "IMMEDIATE_TOKEN",
-                      "content": {
-                        "type": "PREC_RIGHT",
-                        "value": 1,
-                        "content": {
-                          "type": "PATTERN",
-                          "value": "[^\"\\\\$]+"
-                        }
-                      }
-                    },
-                    {
-                      "type": "SYMBOL",
-                      "name": "escape_sequence"
-                    },
-                    {
-                      "type": "SYMBOL",
-                      "name": "string_interpolation"
-                    }
-                  ]
-                }
-              },
-              {
-                "type": "SYMBOL",
-                "name": "__double_quote"
-              }
-            ]
-          }
-        ]
-      }
+            },
+            {
+              "type": "STRING",
+              "value": "\""
+            }
+          ]
+        }
+      ]
     },
     "string_interpolation": {
       "type": "SEQ",
@@ -6319,8 +6305,8 @@
         {
           "type": "ALIAS",
           "content": {
-            "type": "SYMBOL",
-            "name": "__dolcbr"
+            "type": "STRING",
+            "value": "${"
           },
           "named": true,
           "value": "interpolation_opening"
@@ -6363,8 +6349,8 @@
         {
           "type": "ALIAS",
           "content": {
-            "type": "SYMBOL",
-            "name": "__rcbr"
+            "type": "STRING",
+            "value": "}"
           },
           "named": true,
           "value": "interpolation_closing"
@@ -8479,62 +8465,6 @@
             }
           }
         ]
-      }
-    },
-    "__dolcbr": {
-      "type": "TOKEN",
-      "content": {
-        "type": "STRING",
-        "value": "${"
-      }
-    },
-    "__rcbr": {
-      "type": "TOKEN",
-      "content": {
-        "type": "STRING",
-        "value": "}"
-      }
-    },
-    "__double_quote": {
-      "type": "TOKEN",
-      "content": {
-        "type": "STRING",
-        "value": "\""
-      }
-    },
-    "__single_quote": {
-      "type": "TOKEN",
-      "content": {
-        "type": "STRING",
-        "value": "'"
-      }
-    },
-    "__c_double_quote": {
-      "type": "TOKEN",
-      "content": {
-        "type": "STRING",
-        "value": "c\""
-      }
-    },
-    "__c_single_quote": {
-      "type": "TOKEN",
-      "content": {
-        "type": "STRING",
-        "value": "c'"
-      }
-    },
-    "__r_double_quote": {
-      "type": "TOKEN",
-      "content": {
-        "type": "STRING",
-        "value": "r\""
-      }
-    },
-    "__r_single_quote": {
-      "type": "TOKEN",
-      "content": {
-        "type": "STRING",
-        "value": "r'"
       }
     }
   },

--- a/tree_sitter_v/src/node-types.json
+++ b/tree_sitter_v/src/node-types.json
@@ -853,7 +853,7 @@
     "fields": {},
     "children": {
       "multiple": true,
-      "required": false,
+      "required": true,
       "types": [
         {
           "type": "capture",
@@ -950,20 +950,21 @@
   {
     "type": "compile_time_selector_expression",
     "named": true,
-    "fields": {},
-    "children": {
-      "multiple": false,
-      "required": true,
-      "types": [
-        {
-          "type": "reference_expression",
-          "named": true
-        },
-        {
-          "type": "selector_expression",
-          "named": true
-        }
-      ]
+    "fields": {
+      "field": {
+        "multiple": false,
+        "required": true,
+        "types": [
+          {
+            "type": "reference_expression",
+            "named": true
+          },
+          {
+            "type": "selector_expression",
+            "named": true
+          }
+        ]
+      }
     }
   },
   {
@@ -2061,11 +2062,6 @@
         ]
       }
     }
-  },
-  {
-    "type": "interpolation_closing",
-    "named": true,
-    "fields": {}
   },
   {
     "type": "interpreted_string_literal",
@@ -4061,7 +4057,7 @@
     "fields": {},
     "children": {
       "multiple": true,
-      "required": false,
+      "required": true,
       "types": [
         {
           "type": "type_parameter_declaration",
@@ -4301,6 +4297,10 @@
     "named": false
   },
   {
+    "type": "\"",
+    "named": false
+  },
+  {
     "type": "#",
     "named": false
   },
@@ -4314,6 +4314,10 @@
   },
   {
     "type": "$",
+    "named": false
+  },
+  {
+    "type": "$(",
     "named": false
   },
   {
@@ -4354,6 +4358,10 @@
   },
   {
     "type": "&^=",
+    "named": false
+  },
+  {
+    "type": "'",
     "named": false
   },
   {
@@ -4553,6 +4561,14 @@
     "named": false
   },
   {
+    "type": "c\"",
+    "named": false
+  },
+  {
+    "type": "c'",
+    "named": false
+  },
+  {
     "type": "chan",
     "named": false
   },
@@ -4629,6 +4645,10 @@
     "named": false
   },
   {
+    "type": "interpolation_closing",
+    "named": true
+  },
+  {
     "type": "interpolation_opening",
     "named": true
   },
@@ -4678,6 +4698,14 @@
   },
   {
     "type": "pub",
+    "named": false
+  },
+  {
+    "type": "r\"",
+    "named": false
+  },
+  {
+    "type": "r'",
     "named": false
   },
   {

--- a/tree_sitter_v/test/corpus/string_literal.txt
+++ b/tree_sitter_v/test/corpus/string_literal.txt
@@ -405,6 +405,27 @@ String literal with escape sequences
         (escape_sequence)))))
 
 ================================================================================
+String literal with identifier tokens
+================================================================================
+'$Hello'
+'C.Hello $World'
+'@Hello
+$
+JS.World'
+--------------------------------------------------------------------------------
+
+(source_file
+  (simple_statement
+    (literal
+      (interpreted_string_literal)))
+  (simple_statement
+    (literal
+      (interpreted_string_literal)))
+  (simple_statement
+    (literal
+      (interpreted_string_literal))))
+
+================================================================================
 String literal with interpolation after \n
 ================================================================================
 'v fmt failed:\n\n${res.output}'


### PR DESCRIPTION
Until now when encountering a doller sign in a string literal the parser run into an error. An example how this impacted highlighting:

Current:
![Screenshot_20240331_234045](https://github.com/vlang/v-analyzer/assets/34311583/3a547bba-2f5a-4575-b400-7254842eee07)

Updated:
![Screenshot_20240331_234107](https://github.com/vlang/v-analyzer/assets/34311583/6aea5862-57fe-4495-8e7c-ccc69aba8859)
