### PR TITLE
analyzer: use latest install script when updating

### DIFF
--- a/src/up.v
+++ b/src/up.v
@@ -5,8 +5,7 @@ import term
 import os
 
 pub const analyzer_install_script_download_path = 'https://raw.githubusercontent.com/vlang/v-analyzer/main/install.vsh'
-pub const analyzer_install_script_path = os.join_path(os.home_dir(), '.config', 'v-analyzer',
-	'install.vsh')
+pub const analyzer_install_script_path = os.join_path(os.vtmp_dir(), 'v-analzyer', 'install.vsh')
 
 fn up_cmd(cmd cli.Command) ! {
 	download_install_vsh()!

--- a/src/utils.v
+++ b/src/utils.v
@@ -21,10 +21,6 @@ pub fn successln(msg string) {
 }
 
 pub fn download_install_vsh() ! {
-	if os.exists(analyzer_install_script_path) {
-		return
-	}
-
 	http.download_file(analyzer_install_script_download_path, analyzer_install_script_path) or {
 		return error('Failed to download script: ${err}')
 	}


### PR DESCRIPTION
Fixes #11 

If there were installs from the prior v-analyzer repo running v-analyzer up can currently cause several issues. 

For a reproduction, put the install script of the old repo into v-analyzers config dir 
(e.g. `~/.config/v-analyzer/install.vsh`). That's the location that v-analzyer is currently looking for a script and it won't fetch a fresh script when it finds it.

https://github.com/v-analyzer/v-analyzer/blob/main/install.vsh

Then after running `v-analzyer up`, even with the latest nightly version. It will "update" / "downgrade" to the latest release of the old repo.
