### PR TITLE
analyzer: fix work progress shown as 0% when finishing indexing

### DIFF
--- a/src/server/progress/progress.v
+++ b/src/server/progress/progress.v
@@ -79,6 +79,7 @@ pub fn (mut wd WorkDone) end(message string) {
 		value: lsp.WorkDoneProgressPayload{
 			kind: 'end'
 			message: message
+			percentage: 100
 		}
 	)
 }


### PR DESCRIPTION
The end message that prints the indexing progress doesn't pass a percentage anymore, which result in showing a 0% when the indexing finishes. The method is only called once after the indexing has really finished, so we can add the 100 as percentage field here.

*Screenshots below show the result on the bottom right*
|Current|Updated|
|:-:|:-:|
|![Screenshot_20240405_135952](https://github.com/vlang/v-analyzer/assets/34311583/095d45b2-56c9-446a-b0f3-a9905804954a)|![Screenshot_20240405_135952 (1)](https://github.com/vlang/v-analyzer/assets/34311583/0b9f9bab-1eda-470a-887f-c87cf646d065)|
