### PR TITLE
fix-setup_vpaths

### DIFF
--- a/src/server/general.v
+++ b/src/server/general.v
@@ -308,7 +308,7 @@ fn (mut ls LanguageServer) setup_vpaths() ! {
 	}
 	ls.paths.vlib_root = vlib_path
 	vmodules_root := os.vmodules_dir()
-	if !os.is_dir(ls.paths.vmodules_root) {
+	if !os.is_dir(vmodules_root) {
 		return error('Failed to find vmodules path')
 	}
 	ls.paths.vmodules_root = vmodules_root


### PR DESCRIPTION
The second line code `ls.paths.vmodules_root` path has not been set yet.So replace it with `vmodules_root` should be correct.
### original
```v
// src/server/general.v

vmodules_root := os.vmodules_dir()
if !os.is_dir(ls.paths.vmodules_root) {
    return error('Failed to find vmodules path')
}
ls.paths.vmodules_root = vmodules_root
```

### current
```v
// src/server/general.v

vmodules_root := os.vmodules_dir()
if !os.is_dir(vmodules_root) {
    return error('Failed to find vmodules path')
}
ls.paths.vmodules_root = vmodules_root
```