### PR TITLE
test: add test for toolchain path setup

### DIFF
--- a/src/loglib/Logger.v
+++ b/src/loglib/Logger.v
@@ -15,7 +15,7 @@ pub const support_colors = term.can_show_color_on_stderr() && term.can_show_colo
 
 @[heap]
 pub struct Logger {
-mut:
+pub mut:
 	disabled   bool
 	color_mode ColorMode
 

--- a/src/server/protocol/Client.v
+++ b/src/server/protocol/Client.v
@@ -25,6 +25,11 @@ pub fn (mut c Client) progress(params lsp.ProgressParams) {
 
 // log_message sends a window/logMessage notification to the client
 pub fn (mut c Client) log_message(message string, typ lsp.MessageType) {
+	$if test {
+		if c == unsafe { nil } {
+			return
+		}
+	}
 	c.wr.write_notify('window/logMessage', lsp.LogMessageParams{
 		@type: typ
 		message: message

--- a/src/server/setup_test.v
+++ b/src/server/setup_test.v
@@ -1,12 +1,68 @@
 module server
 
 import os
+import lsp
+import loglib as _ // import to use __global `logger`
 
-fn test_setup_vpaths() {
+const default_vexe = @VEXE
+const default_vroot = os.dir(default_vexe)
+const default_vlib_root = os.join_path(default_vroot, 'vlib')
+const default_vmodules_root = os.vmodules_dir()
+
+fn test_setup_default_vpaths() {
 	mut ls := LanguageServer{}
 	ls.setup()
-	assert ls.paths.vexe == @VEXE
-	assert ls.paths.vroot == os.dir(ls.paths.vexe)
-	assert ls.paths.vmodules_root == os.vmodules_dir()
-	assert ls.paths.vlib_root == os.join_path(ls.paths.vroot, 'vlib')
+	assert ls.paths.vexe == default_vexe
+	assert ls.paths.vroot == default_vroot
+	assert ls.paths.vlib_root == default_vlib_root
+	assert ls.paths.vmodules_root == default_vmodules_root
+}
+
+fn test_setup_custom_vpaths() {
+	mut ls := LanguageServer{}
+
+	custom_root := os.join_path(os.vtmp_dir(), 'v-analyzer-setup-test')
+	custom_root_uri := lsp.document_uri_from_path(custom_root)
+	cfg_dir_path := os.join_path(custom_root, '.v-analyzer')
+	os.mkdir_all(cfg_dir_path)!
+	defer {
+		os.rmdir_all(cfg_dir_path) or {}
+	}
+
+	// Test custom_vroot with missing toolchain ==================================
+	mut cfg_toml := 'custom_vroot = "${custom_root}"'
+	os.write_file(os.join_path(custom_root, '.v-analyzer', 'config.toml'), cfg_toml)!
+
+	// Set output(io.Writer) for global loglib logger.
+	log_file_path := os.join_path(custom_root, 'log')
+	os.write_file(log_file_path, '')!
+	mut log_file := os.open_append(os.join_path(custom_root, 'log'))!
+	logger.out = log_file
+
+	// Run setup
+	ls.root_uri = custom_root_uri
+	ls.setup()
+
+	log_file.close()
+	mut log_out := os.read_file(log_file_path)!
+	assert log_out.contains('Find custom VROOT path')
+	assert log_out.contains('Using "${custom_root}" as toolchain')
+	assert log_out.contains('Failed to find standard library path')
+
+	// Test custom_vroot with existing toolchain =================================
+	cfg_toml = 'custom_vroot = "${default_vroot}"'
+	os.write_file(os.join_path(custom_root, '.v-analyzer', 'config.toml'), cfg_toml)!
+	os.write_file(log_file_path, '')!
+	log_file = os.open_append(os.join_path(custom_root, 'log'))!
+	logger.out = log_file
+	ls = LanguageServer{}
+	ls.root_uri = custom_root_uri
+
+	ls.setup()
+
+	log_file.close()
+	log_out = os.read_file(log_file_path)!
+	assert log_out.contains('Find custom VROOT path')
+	assert log_out.contains('Using "${default_vroot}" as toolchain')
+	assert !log_out.contains('Failed to find standard library path')
 }

--- a/src/server/setup_test.v
+++ b/src/server/setup_test.v
@@ -12,10 +12,10 @@ const default_vmodules_root = os.vmodules_dir()
 fn test_setup_default_vpaths() {
 	mut ls := LanguageServer{}
 	ls.setup()
-	assert ls.paths.vexe == default_vexe
-	assert ls.paths.vroot == default_vroot
-	assert ls.paths.vlib_root == default_vlib_root
-	assert ls.paths.vmodules_root == default_vmodules_root
+	assert ls.paths.vexe == server.default_vexe
+	assert ls.paths.vroot == server.default_vroot
+	assert ls.paths.vlib_root == server.default_vlib_root
+	assert ls.paths.vmodules_root == server.default_vmodules_root
 }
 
 fn test_setup_custom_vpaths() {
@@ -50,7 +50,7 @@ fn test_setup_custom_vpaths() {
 	assert log_out.contains('Failed to find standard library path')
 
 	// Test custom_vroot with existing toolchain =================================
-	cfg_toml = 'custom_vroot = "${default_vroot}"'
+	cfg_toml = 'custom_vroot = "${server.default_vroot}"'
 	os.write_file(os.join_path(custom_root, '.v-analyzer', 'config.toml'), cfg_toml)!
 	os.write_file(log_file_path, '')!
 	log_file = os.open_append(os.join_path(custom_root, 'log'))!
@@ -63,6 +63,6 @@ fn test_setup_custom_vpaths() {
 	log_file.close()
 	log_out = os.read_file(log_file_path)!
 	assert log_out.contains('Find custom VROOT path')
-	assert log_out.contains('Using "${default_vroot}" as toolchain')
+	assert log_out.contains('Using "${server.default_vroot}" as toolchain')
 	assert !log_out.contains('Failed to find standard library path')
 }

--- a/src/server/setup_test.v
+++ b/src/server/setup_test.v
@@ -1,0 +1,12 @@
+module server
+
+import os
+
+fn test_setup_vpaths() {
+	mut ls := LanguageServer{}
+	ls.setup()
+	assert ls.paths.vexe == @VEXE
+	assert ls.paths.vroot == os.dir(ls.paths.vexe)
+	assert ls.paths.vmodules_root == os.vmodules_dir()
+	assert ls.paths.vlib_root == os.join_path(ls.paths.vroot, 'vlib')
+}

--- a/src/server/setup_test.v
+++ b/src/server/setup_test.v
@@ -45,6 +45,8 @@ fn test_setup_custom_vpaths() {
 
 	log_file.close()
 	mut log_out := os.read_file(log_file_path)!
+	println('Testlog custom_vroot missing toolchain:')
+	println(log_out.trim_space())
 	assert log_out.contains('Find custom VROOT path')
 	assert log_out.contains('Using "${custom_root}" as toolchain')
 	assert log_out.contains('Failed to find standard library path')
@@ -62,6 +64,8 @@ fn test_setup_custom_vpaths() {
 
 	log_file.close()
 	log_out = os.read_file(log_file_path)!
+	println('Testlog custom_vroot existing toolchain:')
+	println(log_out.trim_space())
 	assert log_out.contains('Find custom VROOT path')
 	assert log_out.contains('Using "${server.default_vroot}" as toolchain')
 	assert !log_out.contains('Failed to find standard library path')


### PR DESCRIPTION
- [x] Custom config test
- [x] Fix windows tests

To test custom paths and errors the test currently redirects the output of the global logger that is defined in the loglib.

The test can be simplified when the severs initialization and setup process has progressed in it's error handling. For now, the used approach should work for asserting that paths have been set properly.