### PR TITLE
ci: use dedicated lint workflow to verify formatting

### DIFF
--- a/.github/workflows/analyzer_tests.yml
+++ b/.github/workflows/analyzer_tests.yml
@@ -64,15 +64,3 @@ jobs:
         # TODO: include Windows
         if: runner.os != 'Windows'
         run: v .github/workflows/version_test.vv
-
-      - name: Verify formatting
-        shell: bash
-        run: |
-          set +e
-          v fmt -c .
-          exit_code=$?
-          # Don't fail on internal errors.
-          if [[ $exit_code -ne 0 && $exit_code -ne 5 ]]; then
-            v fmt -diff .
-            exit 1
-          fi

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,40 @@
+name: Lint
+
+on:
+  push:
+    paths:
+      - '**.v'
+      - '**/lint.yml'
+  pull_request:
+    paths:
+      - '**.v'
+      - '**/lint.yml'
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}
+  cancel-in-progress: true
+
+jobs:
+  fmt:
+    runs-on: ubuntu-20.04
+
+    steps:
+      - name: Install V
+        id: install-v
+        uses: vlang/setup-v@v1.4
+        with:
+          check-latest: true
+
+      - name: Checkout v-analyzer
+        uses: actions/checkout@v4
+
+      - name: Verify formatting
+        run: |
+          set +e
+          v fmt -c .
+          exit_code=$?
+          # Don't fail on internal errors.
+          if [[ $exit_code -ne 0 && $exit_code -ne 5 ]]; then
+            v fmt -diff .
+            exit 1
+          fi


### PR DESCRIPTION
Splits the formatting verification into a separate workflow since there is no need to test if v fmt works on every platform in v-analyzer.