### PR TITLE
analyzer: add module index paths and wrapper module path as code block

### DIFF
--- a/src/server/documentation/provider.v
+++ b/src/server/documentation/provider.v
@@ -129,7 +129,7 @@ fn (mut p Provider) import_spec_documentation(element psi.ImportSpec) ? {
 	p.write_separator()
 
 	p.sb.write_string('---\n')
-	p.sb.write_string('${dir}\n')
+	p.sb.write_string('```${dir}```\n')
 }
 
 fn (mut p Provider) module_documentation(element psi.ModuleClause) ? {

--- a/src/server/general.v
+++ b/src/server/general.v
@@ -106,6 +106,12 @@ pub fn (mut ls LanguageServer) initialized(mut wr ResponseWriter) {
 
 	if need_index_stdlib {
 		ls.indexing_mng.indexer.add_indexing_root(ls.paths.vmodules_root, .modules, ls.paths.cache_dir)
+		for path in os.vmodules_paths()[1..] {
+			if path.is_blank() {
+				continue
+			}
+			ls.indexing_mng.indexer.add_indexing_root(path, .modules, ls.paths.cache_dir)
+		}
 		ls.indexing_mng.indexer.add_indexing_root(ls.paths.vlib_root, .standard_library,
 			ls.paths.cache_dir)
 	}


### PR DESCRIPTION
## 1.Module index path is missing
When the `VMODULES` environment variable is defined, other module paths need to be added to the index so that lsp can parse them correctly.

## 2.Module path is escaped incorrectly
* dir -> escaped
<img width="382" alt="impor_path_before_1" src="https://github.com/vlang/v-analyzer/assets/7117454/01fa3e2c-78ab-4dcd-9619-6e806f02b553">

* dir -> wrapper as code block
<img width="395" alt="impor_path_after_1" src="https://github.com/vlang/v-analyzer/assets/7117454/3ce93244-25a6-4b7a-a6b6-3193327aa173">
