### PR TITLE
chore: remove useless `compiler_flag` and copy `.exe` on windows

### DIFF
--- a/install.vsh
+++ b/install.vsh
@@ -340,10 +340,8 @@ fn clone_repository() ! {
 fn build_from_sources() ! {
 	println('Building ${term.bold('v-analyzer')}...')
 
-	compiler_flag := $if windows { '-cc gcc' } $else { '' }
-
 	chdir(analyzer_sources_dir_path)!
-	install_deps_cmd := os.execute('v ${compiler_flag} install')
+	install_deps_cmd := os.execute('v install')
 	if install_deps_cmd.exit_code != 0 {
 		errorln('Failed to install dependencies for ${term.bold('v-analyzer')}')
 		eprintln(install_deps_cmd.output)
@@ -353,7 +351,7 @@ fn build_from_sources() ! {
 	println('${term.green('✓')} Dependencies for ${term.bold('v-analyzer')} installed successfully')
 
 	chdir(analyzer_sources_dir_path)!
-	exit_code := run_command('v ${compiler_flag} build.vsh 1>/dev/null') or {
+	exit_code := run_command('v build.vsh 1>/dev/null') or {
 		errorln('Failed to build ${term.bold('v-analyzer')}: ${err}')
 		return
 	}
@@ -369,7 +367,7 @@ fn build_from_sources() ! {
 		return
 	}
 
-	os.cp_all('${analyzer_sources_dir_path}/bin/v-analyzer', analyzer_bin_dir_path, true) or {
+	os.cp_all('${analyzer_sources_dir_path}/bin/v-analyzer' + $if windows { '.exe' } $else { '' }, analyzer_bin_dir_path, true) or {
 		println('Failed to copy ${term.bold('v-analyzer')} binary to ${analyzer_bin_dir_path}: ${err}')
 		return
 	}


### PR DESCRIPTION
`v install` should not be concerned with compilation flags.
And the actual compiler is determined by `build.vsh`:
<details>

```
PS C:\Users\***\.config\v-analyzer> $Env:CC = 'clang'
PS C:\Users\***\.config\v-analyzer> v .\install.vsh up --nightly
Installing latest nightly version...
Updating v-analyzer sources...
✓ Successfully updated v-analyzer sources
Building v-analyzer...
✓ Dependencies for v-analyzer installed successfully
Building v-analyzer at commit: 7e11a6f, build time: 2024-06-15 01:17:19 ...
✓ Prepared output directory
Building v-analyzer in debug mode, using: "E:\Programs\v\v.exe" "C:\Users\***\.config\v-analyzer\sources" -o "./bin/v-analyzer.exe" -no-parallel -cc clang  -g
To build in release mode, run v build.vsh release
Release mode is recommended for production use. At runtime, it is about 30-40% faster than debug mode.
✓ Successfully built v-analyzer!
Binary is located at C:\Users\***\.config\v-analyzer\sources\bin\v-analyzer.exe

Moving v-analyzer binary to the standard location...
Failed to copy v-analyzer binary to C:\Users\***\.config\v-analyzer\bin: Failed to remove "C:\Users\***\.config\v-analyzer\bin\v-analyzer.exe": Permission denied; code: 13
✓ v-analyzer successfully updated to nightly (7e11a6f8f369df935664fadd2f0c99d90fe3226f)
Path to the binary: C:\Users\***\.config\v-analyzer\bin\v-analyzer
```

</details>

Also, the executable has `.exe` extension on Windows, thus `v-analyzer.exe` should be copied on Windows