### PR TITLE
Fix goto definition for field names.

### DIFF
--- a/tree_sitter_v/grammar.js
+++ b/tree_sitter_v/grammar.js
@@ -561,9 +561,12 @@ module.exports = grammar({
 		short_element_list: ($) =>
 			repeat1(seq(alias($._expression, $.element), optional(list_separator))),
 
+		field_name: ($) =>
+			$.reference_expression,
+
 		keyed_element: ($) =>
 			seq(
-				field('key', alias($.reference_expression, $.field_name)),
+				field('key', $.field_name),
 				':',
 				field('value', $._expression),
 			),

--- a/tree_sitter_v/package.json
+++ b/tree_sitter_v/package.json
@@ -1,59 +1,49 @@
 {
-	"name": "tree-sitter-v",
-	"version": "0.0.4-beta.1",
-	"main": "bindings/node",
-	"types": "bindings/node",
-	"license": "MIT",
-	"repository": {
-		"type": "git",
-		"url": "https://github.com/vlang/v-analyzer.git"
-	},
-	"scripts": {
-		"test": "tree-sitter test",
-		"generate": "tree-sitter generate --no-bindings && v run bindings/generate_types.vsh",
-		"parse": "tree-sitter parse",
-		"parseg": "tree-sitter parse --debug-graph",
-		"install": "node-gyp-build",
-		"prebuildify": "prebuildify --napi --strip",
-		"lint": "eslint \"**/*.js\"",
-		"format": "prettier --write \"**/*.js\"",
-		"format:check": "prettier --check \"**/*.js\""
-	},
-	"dependencies": {
-		"node-addon-api": "^8.0.0",
-		"node-gyp-build": "^4.8.0"
-	},
-	"peerDependencies": {
-		"tree-sitter": "^0.21.1"
-	},
-	"peerDependenciesMeta": {
-		"tree_sitter": {
-			"optional": true
-		}
-	},
-	"devDependencies": {
-		"eslint": "^8.57.0",
-		"eslint-config-google": "^0.14.0",
-		"eslint-config-prettier": "^9.1.0",
-		"prebuildify": "^6.0.0",
-		"prettier": "^3.2.5",
-		"tree-sitter-cli": "^0.22.2"
-	},
-	"tree-sitter": [
-		{
-			"scope": "source.v",
-			"file-types": [
-				"v",
-				"vsh",
-				"v.mod"
-			]
-		}
-	],
-	"files": [
-		"grammar.js",
-		"prebuilds/**",
-		"bindings/node/*",
-		"queries/*",
-		"src/**"
-	]
+  "name": "tree-sitter-v",
+  "version": "0.0.4-beta.1",
+  "main": "bindings/node",
+  "types": "bindings/node",
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/vlang/v-analyzer.git"
+  },
+  "scripts": {
+    "test": "tree-sitter test",
+    "generate": "tree-sitter generate --no-bindings && v run bindings/generate_types.vsh",
+    "parse": "tree-sitter parse",
+    "parseg": "tree-sitter parse --debug-graph",
+    "install": "node-gyp-build",
+    "prebuildify": "prebuildify --napi --strip",
+    "lint": "eslint \"**/*.js\"",
+    "format": "prettier --write \"**/*.js\"",
+    "format:check": "prettier --check \"**/*.js\""
+  },
+  "dependencies": {
+    "node-addon-api": "^8.0.0",
+    "node-gyp-build": "^4.8.0"
+  },
+  "peerDependencies": {
+    "tree-sitter": "^0.21.1"
+  },
+  "peerDependenciesMeta": {
+    "tree_sitter": {
+      "optional": true
+    }
+  },
+  "devDependencies": {
+    "eslint": "^8.57.0",
+    "eslint-config-google": "^0.14.0",
+    "eslint-config-prettier": "^9.1.0",
+    "prebuildify": "^6.0.0",
+    "prettier": "^3.2.5",
+    "tree-sitter-cli": "^0.22.2"
+  },
+  "files": [
+    "grammar.js",
+    "prebuilds/**",
+    "bindings/node/*",
+    "queries/*",
+    "src/**"
+  ]
 }

--- a/tree_sitter_v/src/grammar.json
+++ b/tree_sitter_v/src/grammar.json
@@ -3044,6 +3044,10 @@
         ]
       }
     },
+    "field_name": {
+      "type": "SYMBOL",
+      "name": "reference_expression"
+    },
     "keyed_element": {
       "type": "SEQ",
       "members": [
@@ -3051,13 +3055,8 @@
           "type": "FIELD",
           "name": "key",
           "content": {
-            "type": "ALIAS",
-            "content": {
-              "type": "SYMBOL",
-              "name": "reference_expression"
-            },
-            "named": true,
-            "value": "field_name"
+            "type": "SYMBOL",
+            "name": "field_name"
           }
         },
         {

--- a/tree_sitter_v/src/grammar.json
+++ b/tree_sitter_v/src/grammar.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "https://tree-sitter.github.io/tree-sitter/assets/schemas/grammar.schema.json",
   "name": "v",
   "word": "identifier",
   "rules": {

--- a/tree_sitter_v/src/node-types.json
+++ b/tree_sitter_v/src/node-types.json
@@ -3557,6 +3557,7 @@
   {
     "type": "source_file",
     "named": true,
+    "root": true,
     "fields": {},
     "children": {
       "multiple": true,

--- a/tree_sitter_v/src/node-types.json
+++ b/tree_sitter_v/src/node-types.json
@@ -1278,7 +1278,7 @@
       "required": true,
       "types": [
         {
-          "type": "identifier",
+          "type": "reference_expression",
           "named": true
         }
       ]

--- a/tree_sitter_v/src/tree_sitter/alloc.h
+++ b/tree_sitter_v/src/tree_sitter/alloc.h
@@ -12,10 +12,10 @@ extern "C" {
 // Allow clients to override allocation functions
 #ifdef TREE_SITTER_REUSE_ALLOCATOR
 
-extern void *(*ts_current_malloc)(size_t);
-extern void *(*ts_current_calloc)(size_t, size_t);
-extern void *(*ts_current_realloc)(void *, size_t);
-extern void (*ts_current_free)(void *);
+extern void *(*ts_current_malloc)(size_t size);
+extern void *(*ts_current_calloc)(size_t count, size_t size);
+extern void *(*ts_current_realloc)(void *ptr, size_t size);
+extern void (*ts_current_free)(void *ptr);
 
 #ifndef ts_malloc
 #define ts_malloc  ts_current_malloc

--- a/tree_sitter_v/test/corpus/anon_struct.txt
+++ b/tree_sitter_v/test/corpus/anon_struct.txt
@@ -115,11 +115,13 @@ a := struct {
           (element_list
             (keyed_element
               (field_name
-                (identifier))
+                (reference_expression
+                  (identifier)))
               (literal
                 (interpreted_string_literal)))
             (keyed_element
               (field_name
-                (identifier))
+                (reference_expression
+                  (identifier)))
               (literal
                 (interpreted_string_literal)))))))))

--- a/tree_sitter_v/test/corpus/call_expression.txt
+++ b/tree_sitter_v/test/corpus/call_expression.txt
@@ -240,7 +240,8 @@ foo(name: value)
         (argument
           (keyed_element
             (field_name
-              (identifier))
+              (reference_expression
+                (identifier)))
             (reference_expression
               (identifier))))))))
 
@@ -259,19 +260,22 @@ foo(name: value, name2: value2, name3: value3)
         (argument
           (keyed_element
             (field_name
-              (identifier))
+              (reference_expression
+                (identifier)))
             (reference_expression
               (identifier))))
         (argument
           (keyed_element
             (field_name
-              (identifier))
+              (reference_expression
+                (identifier)))
             (reference_expression
               (identifier))))
         (argument
           (keyed_element
             (field_name
-              (identifier))
+              (reference_expression
+                (identifier)))
             (reference_expression
               (identifier))))))))
 
@@ -296,19 +300,22 @@ foo(plain, plain2, name: value, name2: value2, name3: value3)
         (argument
           (keyed_element
             (field_name
-              (identifier))
+              (reference_expression
+                (identifier)))
             (reference_expression
               (identifier))))
         (argument
           (keyed_element
             (field_name
-              (identifier))
+              (reference_expression
+                (identifier)))
             (reference_expression
               (identifier))))
         (argument
           (keyed_element
             (field_name
-              (identifier))
+              (reference_expression
+                (identifier)))
             (reference_expression
               (identifier))))))))
 
@@ -331,19 +338,22 @@ foo(
         (argument
           (keyed_element
             (field_name
-              (identifier))
+              (reference_expression
+                (identifier)))
             (reference_expression
               (identifier))))
         (argument
           (keyed_element
             (field_name
-              (identifier))
+              (reference_expression
+                (identifier)))
             (reference_expression
               (identifier))))
         (argument
           (keyed_element
             (field_name
-              (identifier))
+              (reference_expression
+                (identifier)))
             (reference_expression
               (identifier))))))))
 
@@ -366,19 +376,22 @@ foo(
         (argument
           (keyed_element
             (field_name
-              (identifier))
+              (reference_expression
+                (identifier)))
             (reference_expression
               (identifier))))
         (argument
           (keyed_element
             (field_name
-              (identifier))
+              (reference_expression
+                (identifier)))
             (reference_expression
               (identifier))))
         (argument
           (keyed_element
             (field_name
-              (identifier))
+              (reference_expression
+                (identifier)))
             (reference_expression
               (identifier))))))))
 
@@ -405,19 +418,22 @@ foo(
         (argument
           (keyed_element
             (field_name
-              (identifier))
+              (reference_expression
+                (identifier)))
             (reference_expression
               (identifier))))
         (argument
           (keyed_element
             (field_name
-              (identifier))
+              (reference_expression
+                (identifier)))
             (reference_expression
               (identifier))))
         (argument
           (keyed_element
             (field_name
-              (identifier))
+              (reference_expression
+                (identifier)))
             (reference_expression
               (identifier))))))))
 

--- a/tree_sitter_v/test/corpus/function_literal.txt
+++ b/tree_sitter_v/test/corpus/function_literal.txt
@@ -579,7 +579,8 @@ fn test_with_value() {
                 (element_list
                   (keyed_element
                     (field_name
-                      (identifier))
+                      (reference_expression
+                        (identifier)))
                     (literal
                       (interpreted_string_literal)))))))))
       (simple_statement

--- a/tree_sitter_v/test/corpus/type_initializer.txt
+++ b/tree_sitter_v/test/corpus/type_initializer.txt
@@ -46,7 +46,8 @@ Array type initializer with field
         (element_list
           (keyed_element
             (field_name
-              (identifier))
+              (reference_expression
+                (identifier)))
             (literal
               (int_literal))))))))
 
@@ -68,12 +69,14 @@ Array type initializer with fields
         (element_list
           (keyed_element
             (field_name
-              (identifier))
+              (reference_expression
+                (identifier)))
             (literal
               (int_literal)))
           (keyed_element
             (field_name
-              (identifier))
+              (reference_expression
+                (identifier)))
             (literal
               (int_literal))))))))
 
@@ -95,17 +98,20 @@ Array type initializer with all fields
         (element_list
           (keyed_element
             (field_name
-              (identifier))
+              (reference_expression
+                (identifier)))
             (literal
               (int_literal)))
           (keyed_element
             (field_name
-              (identifier))
+              (reference_expression
+                (identifier)))
             (literal
               (int_literal)))
           (keyed_element
             (field_name
-              (identifier))
+              (reference_expression
+                (identifier)))
             (binary_expression
               (reference_expression
                 (identifier))
@@ -130,7 +136,8 @@ Foo{
         (element_list
           (keyed_element
             (field_name
-              (identifier))
+              (reference_expression
+                (identifier)))
             (literal
               (int_literal))))))))
 
@@ -154,17 +161,20 @@ Foo{
         (element_list
           (keyed_element
             (field_name
-              (identifier))
+              (reference_expression
+                (identifier)))
             (literal
               (int_literal)))
           (keyed_element
             (field_name
-              (identifier))
+              (reference_expression
+                (identifier)))
             (literal
               (interpreted_string_literal)))
           (keyed_element
             (field_name
-              (identifier))
+              (reference_expression
+                (identifier)))
             (literal
               (float_literal))))))))
 
@@ -211,12 +221,14 @@ Foo{
               (identifier)))
           (keyed_element
             (field_name
-              (identifier))
+              (reference_expression
+                (identifier)))
             (literal
               (int_literal)))
           (keyed_element
             (field_name
-              (identifier))
+              (reference_expression
+                (identifier)))
             (literal
               (interpreted_string_literal))))))))
 
@@ -282,7 +294,8 @@ Foo{
         (element_list
           (keyed_element
             (field_name
-              (identifier))
+              (reference_expression
+                (identifier)))
             (type_initializer
               (plain_type
                 (type_reference_expression
@@ -291,12 +304,14 @@ Foo{
                 (element_list
                   (keyed_element
                     (field_name
-                      (identifier))
+                      (reference_expression
+                        (identifier)))
                     (literal
                       (interpreted_string_literal)))
                   (keyed_element
                     (field_name
-                      (identifier))
+                      (reference_expression
+                        (identifier)))
                     (literal
                       (int_literal))))))))))))
 
@@ -323,17 +338,20 @@ Foo{
         (element_list
           (keyed_element
             (field_name
-              (identifier))
+              (reference_expression
+                (identifier)))
             (literal
               (interpreted_string_literal)))
           (keyed_element
             (field_name
-              (identifier))
+              (reference_expression
+                (identifier)))
             (literal
               (int_literal)))
           (keyed_element
             (field_name
-              (identifier))
+              (reference_expression
+                (identifier)))
             (type_initializer
               (plain_type
                 (type_reference_expression
@@ -342,12 +360,14 @@ Foo{
                 (element_list
                   (keyed_element
                     (field_name
-                      (identifier))
+                      (reference_expression
+                        (identifier)))
                     (literal
                       (interpreted_string_literal)))
                   (keyed_element
                     (field_name
-                      (identifier))
+                      (reference_expression
+                        (identifier)))
                     (literal
                       (int_literal))))))))))))
 
@@ -378,12 +398,14 @@ Foo[int, string]{
         (element_list
           (keyed_element
             (field_name
-              (identifier))
+              (reference_expression
+                (identifier)))
             (literal
               (interpreted_string_literal)))
           (keyed_element
             (field_name
-              (identifier))
+              (reference_expression
+                (identifier)))
             (literal
               (int_literal))))))))
 
@@ -406,12 +428,14 @@ C.Foo{
         (element_list
           (keyed_element
             (field_name
-              (identifier))
+              (reference_expression
+                (identifier)))
             (literal
               (interpreted_string_literal)))
           (keyed_element
             (field_name
-              (identifier))
+              (reference_expression
+                (identifier)))
             (literal
               (int_literal))))))))
 

--- a/tree_sitter_v/tree-sitter.json
+++ b/tree_sitter_v/tree-sitter.json
@@ -1,0 +1,31 @@
+{
+  "grammars": [
+    {
+      "name": "v",
+      "camelcase": "V",
+      "scope": "source.v",
+      "path": ".",
+      "file-types": [
+        "v",
+        "vsh",
+        "v.mod"
+      ]
+    }
+  ],
+  "metadata": {
+    "version": "0.0.4-beta.1",
+    "license": "MIT",
+    "description": "v grammar for tree-sitter",
+    "links": {
+      "repository": "https://github.com/vlang/v-analyzer.git"
+    }
+  },
+  "bindings": {
+    "c": true,
+    "go": true,
+    "node": true,
+    "python": true,
+    "rust": true,
+    "swift": true
+  }
+}


### PR DESCRIPTION
Changes Tree-Sitter `field_name` to contain a `reference_expression`.

On top of https://github.com/vlang/v-analyzer/pull/134