### PR TITLE
Fix wrong macos target in release CI

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,6 +36,7 @@ jobs:
             os: ubuntu-20.04
           - target: darwin-x86_64
             os: macos-latest
+            vflags: -d cross_compile_macos_x86_64
           - target: darwin-arm64
             os: macos-latest
             vflags: -d cross_compile_macos_arm64

--- a/build.vsh
+++ b/build.vsh
@@ -39,6 +39,8 @@ fn (m ReleaseMode) compile_cmd() string {
 	}
 	cflags := $if cross_compile_macos_arm64 ? {
 		'-cflags "-target arm64-apple-darwin"'
+	} $else $if cross_compile_macos_x86_64 ? {
+		'-cflags "-target x86_64-apple-darwin"'
 	} $else $if linux {
 		if m == .release { '-cflags -static' } else { '' }
 	} $else {


### PR DESCRIPTION
Both the macos-arm64 and macos-x86_64 targets were building arm64 binaries. This fixes it.