### PR TITLE
fix: incorrect initialization

### DIFF
--- a/src/lsp/completion.v
+++ b/src/lsp/completion.v
@@ -9,7 +9,7 @@ pub mut:
 pub struct CompletionItemSettings {
 	snippet_support           bool     @[json: snippetSupport]
 	commit_characters_support bool     @[json: commitCharactersSupport]
-	documentation_format      bool     @[json: documentationFormat]
+	documentation_format      []string @[json: documentationFormat]
 	preselect_support         bool     @[json: preselectSupport]
 	deprecated_support        bool     @[json: deprecatedSupport]
 	tag_support               ValueSet @[json: tag_support]

--- a/src/lsp/initialize.v
+++ b/src/lsp/initialize.v
@@ -8,7 +8,7 @@ pub mut:
 	client_info            ClientInfo  @[json: clientInfo]
 	root_uri               DocumentUri @[json: rootUri]
 	root_path              DocumentUri @[json: rootPath]
-	initialization_options string      @[json: initializationOptions]
+	initialization_options string      @[json: initializationOptions; skip]
 	capabilities           ClientCapabilities
 	trace                  string
 	workspace_folders      []WorkspaceFolder @[skip]


### PR DESCRIPTION
Fixed incorrect deserialization of some field according to the latest Language Server Protocol specification.

According to [the definition of `InitializeParams`](https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#initializeParams), the field `initializationOptions` with any type should not be an error while deserializing. In CoC.nvim, this field is marked as "deprecated". After checking more implementations, `{}`, `""` and `null` should be acceptable for clients that doesn't use this field to send, but sending `{}` (from CoC.nvim) caused `v-analyzer` to crash.

According to [the definition of `CompletionClientCapabilities`](https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#completionClientCapabilities), the type of `documentationFormat` should be `MarkupKind[]?` (where `MarkupKind` is just `"markdown" | "plaintext"`, according to [the definition](https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#markupContent)), but somehow we are deserializing this thing as `bool`. This also caused `v-analyzer` to crash.