### PR TITLE
fix: prevent parser crash when using 'it' as variable name (fix #157,…

### DIFF
--- a/src/analyzer/psi/utils.v
+++ b/src/analyzer/psi/utils.v
@@ -19,7 +19,7 @@ pub fn get_it_call(element PsiElement) ?&CallExpression {
 	methods_names := ['filter', 'map', 'any', 'all']
 	if mut parent_call is CallExpression {
 		for !is_array_method_call(*parent_call, ...methods_names) {
-			parent_call = parent_call.parent_of_type(.call_expression) or { break }
+			return none
 		}
 	}
 

--- a/src/tests/definitions.v
+++ b/src/tests/definitions.v
@@ -213,6 +213,23 @@ fn definitions() testing.Tester {
 		t.assert_definition_name(first, 'name')!
 	})
 
+	t.test('it as function parameter', fn (mut t testing.Test, mut fixture testing.Fixture) ! {
+		fixture.configure_by_text('1.v', "
+		fn foo(it int) {
+			if i/*caret*/t.str() == 1 {
+				println('one')
+			}
+		}
+		".trim_indent())!
+
+		locations := fixture.definition_at_cursor()
+		t.assert_has_definition(locations)!
+
+		first := locations.first()
+		t.assert_uri(first.target_uri, fixture.current_file_uri())!
+		t.assert_definition_name(first, 'it')!
+	})
+
 	t.slow_test('shell script implicit os module', fn (mut t testing.Test, mut fixture testing.Fixture) ! {
 		fixture.configure_by_text('1.vsh', '
 		abs_/*caret*/path()


### PR DESCRIPTION
… fix #156)

Modified get_it_call() to return none if parent_call is not in ['filter', 'map', 'any', 'all']

According to the documentation ([Array methods](https://docs.vlang.io/v-types.html#array-methods)) the `it` special variable is only used in `filter`, `map`, `any`, or `all`. There is no need to return anything in other cases.

Fixes #157 #156