### PR TITLE
Fix: Use `os.execute` instead of `os.Process` to fix instability

### DIFF
--- a/src/server/inspections/compiler/utils.v
+++ b/src/server/inspections/compiler/utils.v
@@ -73,8 +73,8 @@ fn exec_compiler_diagnostics(compiler_path string, uri lsp.DocumentUri) ?[]inspe
 	defer {
 		p.signal_term() // terminate the process gracefully
 		spawn fn [mut p] () {
-			// 1 second timeout for if the process is still alive
-			time.sleep(time.second)
+			// timeout for if the process is still alive
+			time.sleep(400 * time.millisecond)
 			if p.is_alive() {
 				p.signal_kill()
 			}

--- a/src/server/inspections/compiler/utils.v
+++ b/src/server/inspections/compiler/utils.v
@@ -3,6 +3,7 @@ module compiler
 import os
 import lsp
 import term
+import time
 import server.inspections
 import analyzer.psi
 

--- a/src/server/inspections/compiler/utils.v
+++ b/src/server/inspections/compiler/utils.v
@@ -72,13 +72,13 @@ fn exec_compiler_diagnostics(compiler_path string, uri lsp.DocumentUri) ?[]inspe
 
 	defer {
 		p.signal_term() // terminate the process gracefully
-		spawn fn [mut p] () {
+		spawn fn (mut p os.Process) {
 			// timeout for if the process is still alive
 			time.sleep(400 * time.millisecond)
 			if p.is_alive() {
 				p.signal_kill()
 			}
-		}()
+		}(mut p)
 		p.wait()
 		p.close()
 	}

--- a/src/server/inspections/compiler/utils.v
+++ b/src/server/inspections/compiler/utils.v
@@ -70,6 +70,14 @@ fn exec_compiler_diagnostics(compiler_path string, uri lsp.DocumentUri) ?[]inspe
 	p.set_redirect_stdio()
 
 	defer {
+		p.signal_term() // terminate the process gracefully
+		spawn fn [mut p] () {
+			// 1 second timeout for if the process is still alive
+			time.sleep(time.second)
+			if p.is_alive() {
+				p.signal_kill()
+			}
+		}()
 		p.wait()
 		p.close()
 	}


### PR DESCRIPTION
Fixed the V compiler hanging in some cases.