### PR TITLE
fix:get server binary realpath when from PATH env

### DIFF
--- a/editors/code/src/bootstrap.ts
+++ b/editors/code/src/bootstrap.ts
@@ -27,9 +27,20 @@ export async function bootstrap(): Promise<string> {
 		);
 	}
 
-	const rpath = fs.realpathSync(path);
 	log.info("Using server binary at", path);
-	log.info("Server binary realpath:", rpath);
+	try {
+		const rpath = fs.realpathSync(path);
+		log.info("Server binary realpath:", rpath);
+	} catch (err) {
+		try {
+			const command =
+				process.platform === "win32" ? `where ${path}` : `which ${path}`;
+			const rpath = cp.execSync(command).toString().trim().split("\n")[0];
+			log.info("Server binary realpath:", rpath);
+		} catch (err) {
+			log.error("Error:", err.message);
+		}
+	}
 
 	return path;
 }

--- a/editors/code/src/bootstrap.ts
+++ b/editors/code/src/bootstrap.ts
@@ -27,20 +27,7 @@ export async function bootstrap(): Promise<string> {
 		);
 	}
 
-	log.info("Using server binary at", path);
-	try {
-		const rpath = fs.realpathSync(path);
-		log.info("Server binary realpath:", rpath);
-	} catch (err) {
-		try {
-			const command =
-				process.platform === "win32" ? `where ${path}` : `which ${path}`;
-			const rpath = cp.execSync(command).toString().trim().split("\n")[0];
-			log.info("Server binary realpath:", rpath);
-		} catch (err) {
-			log.error("Error:", err.message);
-		}
-	}
+	log.info("Server binary path:", path);
 
 	return path;
 }


### PR DESCRIPTION
If the v-analyzer path is not set manually, realpathSync throws an exception, preventing the plugin from working properly.