### PR TITLE
Add implements as a keyword

### DIFF
--- a/editors/code/syntaxes/v.tmLanguage.json
+++ b/editors/code/syntaxes/v.tmLanguage.json
@@ -613,7 +613,7 @@
 				},
 				{
 					"name": "keyword.$1.v",
-					"match": "(?<!@)\\b(fn|type|typeof|enum|struct|interface|map|assert|sizeof|__offsetof)\\b"
+					"match": "(?<!@)\\b(fn|type|typeof|enum|struct|implements|interface|map|assert|sizeof|__offsetof)\\b"
 				}
 			]
 		},

--- a/tree_sitter_v/queries/highlights.scm
+++ b/tree_sitter_v/queries/highlights.scm
@@ -73,6 +73,7 @@
  "shared"
  "static"
  "struct"
+ "implements"
  "type"
  "union"
  "unsafe"


### PR DESCRIPTION
This PR adds implements as a keyword to example highlight.scm file and to VS Code extension.